### PR TITLE
Run backend tests with SQLite and PostgreSQL in CI

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -14,10 +14,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Full backend test suite
+  sqlite:
+    name: SQLite full test suite
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run full test suite
+        run: python -m pytest -q
+
+  postgresql:
+    name: PostgreSQL full test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/molmaker_test
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: molmaker_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Check out repository

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,41 @@
+name: Backend tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Full backend test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Run full test suite
+        run: python -m pytest -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
-import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+import os
 import uuid
 from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from auth import verify_token
 from database import Base
@@ -12,15 +14,28 @@ from dependencies import get_db
 from main import create_app
 from models import Group, Job, Request, Structure, Tags, User
 
-# --- In-memory SQLite test database ---
+# --- Test database ---
 
-SQLALCHEMY_TEST_DATABASE_URL = "sqlite:///:memory:"
-
-engine = create_engine(
-    SQLALCHEMY_TEST_DATABASE_URL,
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
+SQLALCHEMY_TEST_DATABASE_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "sqlite:///:memory:",
 )
+
+if SQLALCHEMY_TEST_DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(
+        SQLALCHEMY_TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+else:
+    engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL)
+
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
@@ -66,7 +81,7 @@ def app():
 @pytest.fixture
 def db():
     """
-    Create a clean in-memory database session for each test, tears it down after.
+    Create a clean database session for each test, then remove its tables.
     """
     Base.metadata.create_all(bind=engine)
     session = TestingSessionLocal()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -276,11 +276,9 @@ class TestVerifyJobAccess:
 
         assert verify_job_access(db, "auth0|missing-user", job.job_id) is False
 
-    def test_matching_owner_sub_allows_access_even_without_user_row(self, db, job_factory):
-        """
-        verify_job_access checks ownership before requiring a requester User row.
-        """
-        owner_sub = "auth0|external-owner"
-        job = job_factory(user_sub=owner_sub)
+    def test_matching_owner_sub_allows_access(self, db, user_factory, job_factory):
+        """Job owners can access their own archives."""
+        owner = user_factory(user_sub="auth0|owner")
+        job = job_factory(user_sub=owner.user_sub)
 
-        assert verify_job_access(db, owner_sub, job.job_id) is True
+        assert verify_job_access(db, owner.user_sub, job.job_id) is True

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -134,11 +134,12 @@ class TestStructuresAPI:
         ]
 
     def test_get_structure_by_id_returns_owned_structure(
-        self, client, tag_factory, structure_factory
+        self, client, user_factory, tag_factory, structure_factory
     ):
         """
         GET /structures/{structure_id} should return a structure owned by the current user.
         """
+        user_factory(user_sub="auth0|testuser")
         tag = tag_factory(user_sub="auth0|testuser", name="baseline")
         structure = structure_factory(
             user_sub="auth0|testuser",
@@ -221,12 +222,13 @@ class TestStructuresAPI:
         assert response.json() == []
 
     def test_presigned_structure_url_returns_owned_structure_url(
-        self, client, monkeypatch, structure_factory
+        self, client, monkeypatch, user_factory, structure_factory
     ):
         """
         GET /structures/presigned/{structure_id} should return a download URL for owned structures.
         """
         fake_s3 = _mock_structure_s3(monkeypatch)
+        user_factory(user_sub="auth0|testuser")
         structure = structure_factory(user_sub="auth0|testuser")
 
         response = client.get(f"/structures/presigned/{structure.structure_id}")
@@ -277,10 +279,13 @@ class TestStructuresAPI:
         assert response.json()["detail"] == "Structure not found."
         assert fake_s3.calls == []
 
-    def test_owner_can_soft_delete_structure(self, client, db, structure_factory):
+    def test_owner_can_soft_delete_structure(
+        self, client, db, user_factory, structure_factory
+    ):
         """
         DELETE /structures/{structure_id} should soft-delete an owned structure.
         """
+        user_factory(user_sub="auth0|testuser")
         structure = structure_factory(user_sub="auth0|testuser", is_deleted=False)
 
         response = client.delete(f"/structures/{structure.structure_id}")
@@ -323,11 +328,12 @@ class TestStructuresAPI:
         assert response.json()["detail"] == "Structure not found."
 
     def test_delete_structure_rolls_back_when_commit_fails(
-        self, client, db, monkeypatch, structure_factory
+        self, client, db, monkeypatch, user_factory, structure_factory
     ):
         """
         DELETE /structures/{structure_id} should roll back if the DB commit fails.
         """
+        user_factory(user_sub="auth0|testuser")
         structure = structure_factory(user_sub="auth0|testuser", is_deleted=False)
 
         def fail_commit():
@@ -343,11 +349,12 @@ class TestStructuresAPI:
         assert structure.is_deleted is False
 
     def test_owner_can_update_structure_and_replace_tags(
-        self, client, db, tag_factory, structure_factory
+        self, client, db, user_factory, tag_factory, structure_factory
     ):
         """
         PATCH /structures/{structure_id} should update fields and replace tag relationships.
         """
+        user_factory(user_sub="auth0|testuser")
         old_tag = tag_factory(user_sub="auth0|testuser", name="old")
         existing_tag = tag_factory(user_sub="auth0|testuser", name="existing")
         structure = structure_factory(
@@ -399,11 +406,12 @@ class TestStructuresAPI:
         assert response.json()["detail"] == "Structure not found."
 
     def test_update_structure_rolls_back_when_commit_fails(
-        self, client, db, monkeypatch, tag_factory, structure_factory
+        self, client, db, monkeypatch, user_factory, tag_factory, structure_factory
     ):
         """
         PATCH /structures/{structure_id} should roll back field and tag changes on commit failure.
         """
+        user_factory(user_sub="auth0|testuser")
         old_tag = tag_factory(user_sub="auth0|testuser", name="old")
         structure = structure_factory(
             user_sub="auth0|testuser",
@@ -553,7 +561,7 @@ class TestStructuresAPI:
         assert not list(tmp_path.glob("temp_*.xyz"))
 
     def test_create_structure_saves_uploads_persists_and_links_tags(
-        self, client, db, monkeypatch, tmp_path, tag_factory
+        self, client, db, monkeypatch, tmp_path, user_factory, tag_factory
     ):
         """
         POST /structures/ should save files, upload to S3, persist the row, and link tags.
@@ -562,6 +570,7 @@ class TestStructuresAPI:
 
         fake_s3 = _mock_structure_s3(monkeypatch)
         monkeypatch.setattr(structures_routes, "JOB_DIR", str(tmp_path))
+        user_factory(user_sub="auth0|testuser")
         existing_tag = tag_factory(user_sub="auth0|testuser", name="existing")
 
         response = client.post(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,12 +79,15 @@ class TestGetUserSub:
 
 
 class TestSerializeStructure:
-    def test_serializes_expected_structure_fields(self, structure_factory):
+    def test_serializes_expected_structure_fields(
+        self, user_factory, structure_factory
+    ):
         """
         serialize_structure should convert IDs and datetimes into API-safe values.
         """
         structure_id = uuid.uuid4()
         uploaded_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        user_factory(user_sub="auth0|testuser")
         structure = structure_factory(
             structure_id=structure_id,
             user_sub="auth0|testuser",
@@ -108,7 +111,7 @@ class TestSerializeStructure:
 
 class TestSerializeJob:
     def test_serializes_job_with_relationships_and_runtime(
-        self, job_factory, structure_factory, tag_factory
+        self, user_factory, job_factory, structure_factory, tag_factory
     ):
         """
         serialize_job should include related structures, tag names, timestamps, and flags.
@@ -116,6 +119,7 @@ class TestSerializeJob:
         job_id = uuid.uuid4()
         submitted_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
         completed_at = datetime(2026, 1, 2, 4, 5, 6, tzinfo=timezone.utc)
+        user_factory(user_sub="auth0|testuser")
         structure = structure_factory(name="Methane", formula="CH4")
         first_tag = tag_factory(name="organic")
         second_tag = tag_factory(name="demo")
@@ -164,10 +168,11 @@ class TestSerializeJob:
         assert result["structures"] == [serialize_structure(structure)]
         assert sorted(result["tags"]) == ["demo", "organic"]
 
-    def test_serializes_none_optional_job_fields(self, job_factory):
+    def test_serializes_none_optional_job_fields(self, user_factory, job_factory):
         """
         Optional job fields should serialize as None when absent.
         """
+        user_factory(user_sub="auth0|testuser")
         job = job_factory(
             completed_at=None,
             runtime=None,


### PR DESCRIPTION
## What changed

- Run the full backend test suite on every pull request and every push to `main`.
- Run separate SQLite and PostgreSQL checks so failures are easy to identify.
- Start PostgreSQL 14 for the PostgreSQL check.
- Let the test setup use `TEST_DATABASE_URL` to select a database. SQLite remains the local default.
- Enable foreign-key checks in SQLite tests.
- Fix test data that created jobs and structures without their required user rows.
- Cancel an older workflow run when a newer commit is pushed to the same PR.

## Why

SQLite does not enable foreign-key checks by default and it does not behave exactly like PostgreSQL. Running the suite on both databases catches invalid test data and PostgreSQL-only failures before a PR is merged.

This PR adds the shared PostgreSQL test setup. Tests for a specific feature, such as its migrations or concurrent requests, should be added in the PR that introduces that feature.

## Validation

- SQLite: 232 passed
- PostgreSQL: 232 passed
- Workflow YAML parsed successfully
- No whitespace errors found
