### PR TITLE
feat: Add bond, angle, and dihedral scan API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ S3_BUCKET_NAME=ubchemica-bucket-1
 S3_REGION=ca-central-1
 S3_BUCKET_ROOT=ubchemica
 
+# Calculation limits
+MAX_SCAN_POINTS=200
+
 # Job orchestration
 SUBMISSION_POLL_INTERVAL_SECONDS=5
 SUBMISSION_QUERY_LIMIT=25

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Set BACKEND_ENV_FILE in the process launcher when this file lives elsewhere.
+
 # Database
 DATABASE_USER=[your username]
 DATABASE_PASSWORD=[your password]
@@ -13,9 +15,12 @@ AUTH0_CLIENT_ID=[your Auth0 management API client ID]
 AUTH0_CLIENT_SECRET=[your Auth0 management API client secret]
 
 # Cluster
-CLUSTER_WORK_DIR=[remote cluster work directory]
+CLUSTER_SSH_HOST=cluster
+CLUSTER_DISPATCH_PATH=/home/thachuk/ubchemica/Cluster-API-QC/runner/dispatch.py
 
-# S3; credentials come from boto3's standard AWS credential provider chain
+# S3; ARCHIVE_UPLOAD_ENABLED is the deployment-wide master switch
+# Credentials come from boto3's standard AWS credential provider chain
+ARCHIVE_UPLOAD_ENABLED=true
 S3_BUCKET_NAME=ubchemica-bucket-1
 S3_REGION=ca-central-1
 S3_BUCKET_ROOT=ubchemica

--- a/README.md
+++ b/README.md
@@ -100,12 +100,21 @@ Set the matching database values in `.env`, then create the current schema:
 python -m database
 ```
 
-`.env.example` is the complete backend settings reference. AWS credentials are
-loaded through boto3's standard credential provider chain rather than stored in
-backend-specific settings.
+`.env.example` is the complete backend settings reference. Set
+`BACKEND_ENV_FILE` in the process launcher to select an absolute env-file path;
+when it is unset, the repository `.env` is loaded if present. Process
+environment values take precedence over file values. `BACKEND_ENV_FILE` cannot
+be placed inside the file it selects.
+
+AWS credentials are loaded through boto3's standard credential provider chain
+rather than stored in backend-specific settings. New archive uploads do not
+need AWS credentials when `ARCHIVE_UPLOAD_ENABLED=false`. This setting is the
+deployment-wide master switch. Each calculation submission may also set the
+optional multipart field `upload_archive=false`; it defaults to `true`, but
+cannot override a disabled master switch.
 
 Settings are loaded once and cached separately by the API and each reconciler
-process. Restart those processes after changing `.env`.
+process. Restart those processes after changing their environment configuration.
 
 `SLURM_JOB_TIME_LIMIT_MINUTES` and `SLURM_JOB_MEMORY_MB` control the resources
 the submission reconciler requests for each new Slurm job. The backend passes
@@ -131,9 +140,16 @@ Before enabling the reconcilers, deploy the complete, reviewed
 /home/thachuk/ubchemica/Cluster-API-QC
 ```
 
-Set `CLUSTER_WORK_DIR=/home/thachuk/ubchemica` in the backend environment. The
-backend sends one versioned JSON request to
-`Cluster-API-QC/runner/dispatch.py` over SSH stdin for each cluster operation.
+Set the exact SSH host and remote dispatcher path in the backend environment:
+
+```dotenv
+CLUSTER_SSH_HOST=cluster
+CLUSTER_DISPATCH_PATH=/home/thachuk/ubchemica/Cluster-API-QC/runner/dispatch.py
+```
+
+The backend sends one versioned JSON request to that path over SSH stdin for
+each cluster operation. It does not derive a repository path from a shared work
+directory.
 The supported operations and security boundary are described in
 [Restricted Alliance Dispatch](docs/job-orchestration.md#restricted-alliance-dispatch).
 
@@ -147,8 +163,9 @@ Deployment requires explicit approval:
 3. Restrict the backend SSH key to this exact no-argument command:
    `python3 /home/thachuk/ubchemica/Cluster-API-QC/runner/dispatch.py`.
 4. Through that restricted connection, smoke-test submission and recovery,
-   batched status checks, cancellation, archive upload with returned result
-   data, acknowledged cleanup, invalid JSON, and a shared-service failure.
+   batched status checks, cancellation, enabled and disabled archive upload
+   with returned result data, acknowledged cleanup, invalid JSON, and a
+   shared-service failure.
 5. If any check fails, check out the recorded previous cluster commit and
    restore the previous allow-list rule. Remove only the smoke-test jobs and
    directories created during these checks.
@@ -159,7 +176,9 @@ cluster release.
 
 #### Install the reconciler services
 
-On the server, ensure the environment file is available at `/home/backend/.env`.
+On the server, install the environment file at
+`/etc/molmaker/backend.env`. The provided service selects it with
+`BACKEND_ENV_FILE`; it does not load a second hard-coded environment file.
 Then install and start the `systemd` services for the first time from the
 repository root:
 
@@ -202,7 +221,7 @@ sudo journalctl -u molmaker-reconciler@status.service -f
 
 When diagnosing one job, inspect its saved status, attempt count, failure
 fields, and Slurm ID. If many jobs pause together, first check for a shared
-PostgreSQL, SSH, Slurm, or S3 outage.
+PostgreSQL, SSH, Slurm, or, when archive upload is enabled, S3 outage.
 
 Restarting a reconciler is safe because PostgreSQL retains the job state and
 calculation inputs, while cluster job directories and S3 artifacts use stable
@@ -241,6 +260,8 @@ python -m pre_commit run --all-files
 
 ## Database Schema
 
-The SQLAlchemy models are the authoritative schema. This repository does not
-carry historical database dumps or migrations. Start with an empty database
-and run `python -m database` before starting the API or reconcilers.
+The SQLAlchemy models are the authoritative schema. This change assumes the
+database will be reset rather than migrated. Stop the API and reconcilers,
+recreate the empty database using the deployment procedure, and run
+`python -m database` before restarting them. No data migration or backfill is
+included.

--- a/asset_service.py
+++ b/asset_service.py
@@ -106,6 +106,7 @@ ARTIFACT_FILES = {
     "vib": ("vib.xyz", "chemical/x-xyz"),
     "molden": ("orbitals.molden", "text/plain"),
     "esp": ("ESP.cube", "text/plain"),
+    "scan": ("scan.xyz", "chemical/x-xyz"),
 }
 JOB_RESULT_ARTIFACTS_BY_CALCULATION = {
     CalculationType.energy.value: frozenset(),
@@ -114,6 +115,7 @@ JOB_RESULT_ARTIFACTS_BY_CALCULATION = {
     CalculationType.geometry.value: frozenset({"trajectory"}),
     CalculationType.transition.value: frozenset({"trajectory"}),
     CalculationType.irc.value: frozenset({"trajectory"}),
+    CalculationType.scan.value: frozenset({"scan"}),
     CalculationType.standard.value: frozenset({"trajectory", "vib", "molden", "esp"}),
 }
 

--- a/asset_service.py
+++ b/asset_service.py
@@ -8,7 +8,13 @@ from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload, selectinload
 
-from enum_types import AssetOwnership, CalculationType, JobFailureReason, JobStatus
+from enum_types import (
+    ArchiveUploadStatus,
+    AssetOwnership,
+    CalculationType,
+    JobFailureReason,
+    JobStatus,
+)
 from models import (
     Asset,
     Group,
@@ -122,6 +128,38 @@ JOB_RESULT_ARTIFACTS_BY_CALCULATION = {
 
 class JobResultValidationError(ValueError):
     """A database-bound job result does not match the finished job."""
+
+
+def _validated_archive_outcome(
+    *,
+    archive_uploaded: bool,
+    archive_upload_status: str | ArchiveUploadStatus,
+) -> ArchiveUploadStatus:
+    if type(archive_uploaded) is not bool:
+        raise JobResultValidationError("Archive upload outcome must be a boolean")
+    try:
+        upload_status = ArchiveUploadStatus(archive_upload_status)
+    except (TypeError, ValueError) as error:
+        raise JobResultValidationError("Archive upload status is invalid") from error
+    if archive_uploaded != (upload_status == ArchiveUploadStatus.uploaded):
+        raise JobResultValidationError("Archive upload outcome is inconsistent")
+    return upload_status
+
+
+def set_job_archive_outcome(
+    job: Job,
+    *,
+    archive_uploaded: bool,
+    archive_upload_status: str | ArchiveUploadStatus,
+) -> None:
+    """Stage one internally consistent archive outcome on a job."""
+
+    upload_status = _validated_archive_outcome(
+        archive_uploaded=archive_uploaded,
+        archive_upload_status=archive_upload_status,
+    )
+    job.archive_uploaded = archive_uploaded
+    job.archive_upload_status = upload_status.value
 
 
 def _published_job_status(job: Job) -> str | None:
@@ -310,6 +348,10 @@ def publish_job_result(
     result: Any,
     error: Any,
     artifacts: Any,
+    archive_uploaded: bool = False,
+    archive_upload_status: str | ArchiveUploadStatus = (
+        ArchiveUploadStatus.unavailable
+    ),
     completed_at: datetime | None = None,
 ) -> JobResult:
     """Persist result data and publish the terminal job in one transaction."""
@@ -320,6 +362,10 @@ def publish_job_result(
         raise JobResultValidationError("Terminal status is invalid") from exc
     if job.status not in {JobStatus.finalising.value, terminal_status.value}:
         raise JobResultValidationError("Job is not ready for result publication")
+    validated_archive_status = _validated_archive_outcome(
+        archive_uploaded=archive_uploaded,
+        archive_upload_status=archive_upload_status,
+    )
 
     job_result = upsert_job_result(
         db,
@@ -330,6 +376,11 @@ def publish_job_result(
     )
     job.status = terminal_status.value
     job.is_uploaded = True
+    set_job_archive_outcome(
+        job,
+        archive_uploaded=archive_uploaded,
+        archive_upload_status=validated_archive_status,
+    )
     job.completed_at = job.completed_at or completed_at or datetime.now(timezone.utc)
     job.attempt_count = 0
     if terminal_status != JobStatus.failed:
@@ -391,6 +442,9 @@ def serialize_job(
         "cancel_requested": job.cancel_requested,
         "failure_reason": job.failure_reason,
         "failure_message": job.failure_message,
+        "upload_archive": job.archive_upload_requested,
+        "archive_uploaded": job.archive_uploaded,
+        "archive_upload_status": job.archive_upload_status,
     }
     return result
 

--- a/calculation/job_creation_service.py
+++ b/calculation/job_creation_service.py
@@ -8,14 +8,18 @@ from fastapi import HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 
 from asset_service import get_asset_or_404, set_asset_tags
+from calculation.scan_spec import ScanSpecValidationError, validate_scan_spec
 from enum_types import CalculationType, JobStatus
 from models import Job, JobInput, Structure, User
 from permissions import can_read_asset
+from settings import get_settings
 from utils import commit_or_rollback, read_bounded_upload
 
 INPUT_FILENAME = "input.xyz"
 STANDARD_ANALYSIS_METHOD = "mp2"
 STANDARD_ANALYSIS_BASIS_SET = "6-311+G(2d,p)"
+SCAN_WORKFLOW_METHOD = "ccsd(t)"
+SCAN_WORKFLOW_BASIS_SET = STANDARD_ANALYSIS_BASIS_SET
 MAX_INPUT_XYZ_BYTES = 4 * 1024 * 1024
 MAX_KEYWORDS_BYTES = 256 * 1024
 
@@ -107,21 +111,7 @@ def _read_uploaded_xyz(upload: UploadFile) -> str:
         ) from error
 
 
-def _read_keywords(upload: Optional[UploadFile]) -> Optional[dict[str, Any]]:
-    if upload is None:
-        return None
-    contents = read_bounded_upload(
-        upload,
-        MAX_KEYWORDS_BYTES,
-        "keywords file",
-    )
-    try:
-        keywords = json.loads(contents.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Keywords file must contain a valid JSON object",
-        ) from error
+def _validate_keyword_values(keywords: Any) -> dict[str, Any]:
     if not isinstance(keywords, dict):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -144,6 +134,24 @@ def _read_keywords(upload: Optional[UploadFile]) -> Optional[dict[str, Any]]:
             detail="keywords file is too large",
         )
     return keywords
+
+
+def _read_keywords_file(upload: Optional[UploadFile]) -> Optional[dict[str, Any]]:
+    if upload is None:
+        return None
+    contents = read_bounded_upload(
+        upload,
+        MAX_KEYWORDS_BYTES,
+        "keywords file",
+    )
+    try:
+        keywords = json.loads(contents.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Keywords file must contain a valid JSON object",
+        ) from error
+    return _validate_keyword_values(keywords)
 
 
 def _load_input_xyz(
@@ -176,7 +184,8 @@ def create_calculation_job(
     *,
     source_file: Optional[UploadFile],
     structure_id: Optional[str],
-    keywords: Optional[UploadFile],
+    keywords_file: Optional[UploadFile],
+    keyword_values: Optional[dict[str, Any]] = None,
     job_name: str,
     job_notes: Optional[str],
     tags: Iterable[str],
@@ -205,9 +214,14 @@ def create_calculation_job(
         source_file,
         structure_id,
     )
-    if keywords is not None:
+    if keywords_file is not None and keyword_values is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide keywords as either a file or an object, not both",
+        )
+    if keywords_file is not None:
         _validate_upload_name(
-            keywords,
+            keywords_file,
             extension=".json",
             detail="Invalid keywords file format. Only .json files are allowed.",
         )
@@ -224,7 +238,28 @@ def create_calculation_job(
         source_file=source_file,
         structure_content=source_structure_content,
     )
-    keyword_values = _read_keywords(keywords)
+    if keyword_values is None:
+        keyword_values = _read_keywords_file(keywords_file)
+    else:
+        keyword_values = _validate_keyword_values(keyword_values)
+
+    if calculation_type == CalculationType.scan:
+        if keyword_values is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Scan calculations require a scan specification in keywords",
+            )
+        try:
+            keyword_values = validate_scan_spec(
+                keyword_values,
+                input_xyz=input_xyz,
+                max_points=get_settings().max_scan_points,
+            )
+        except ScanSpecValidationError as error:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid scan specification: {error}",
+            ) from error
 
     # Persist the job, its exact inputs, and its relationships together.
     linked_structure = None

--- a/calculation/job_creation_service.py
+++ b/calculation/job_creation_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from asset_service import get_asset_or_404, set_asset_tags
 from calculation.scan_spec import ScanSpecValidationError, validate_scan_spec
-from enum_types import CalculationType, JobStatus
+from enum_types import ArchiveUploadStatus, CalculationType, JobStatus
 from models import Job, JobInput, Structure, User
 from permissions import can_read_asset
 from settings import get_settings
@@ -189,6 +189,7 @@ def create_calculation_job(
     job_name: str,
     job_notes: Optional[str],
     tags: Iterable[str],
+    upload_archive: bool,
     calculation_type: CalculationType,
     method: str,
     basis_set: str,
@@ -291,6 +292,9 @@ def create_calculation_job(
         is_deleted=False,
         is_public=False,
         is_uploaded=False,
+        archive_upload_requested=upload_archive,
+        archive_uploaded=False,
+        archive_upload_status=ArchiveUploadStatus.pending.value,
         attempt_count=0,
         cancel_requested=False,
     )

--- a/calculation/routes.py
+++ b/calculation/routes.py
@@ -13,11 +13,15 @@ from sqlalchemy.orm import Session
 
 from asset_service import serialize_job
 from auth import verify_token
-from calculation.service import (
+from calculation.job_creation_service import (
+    MAX_KEYWORDS_BYTES,
+    SCAN_WORKFLOW_BASIS_SET,
+    SCAN_WORKFLOW_METHOD,
     STANDARD_ANALYSIS_BASIS_SET,
     STANDARD_ANALYSIS_METHOD,
     create_calculation_job,
 )
+from calculation.scan_spec import ScanSpecValidationError, parse_scan_spec
 from dependencies import get_db
 from enum_types import CalculationType
 from jobs.schemas import JobResponse
@@ -84,7 +88,7 @@ def submit_custom_calculation(
         user,
         source_file=file,
         structure_id=structure_id,
-        keywords=keywords,
+        keywords_file=keywords,
         job_name=job_name,
         job_notes=job_notes,
         tags=tags,
@@ -139,7 +143,7 @@ def submit_standard_analysis(
         user,
         source_file=file,
         structure_id=structure_id,
-        keywords=None,
+        keywords_file=None,
         job_name=job_name,
         job_notes=job_notes,
         tags=tags,
@@ -149,6 +153,71 @@ def submit_standard_analysis(
         charge=charge,
         multiplicity=multiplicity,
         optimization_type=optimization_type,
+    )
+
+    return serialize_job(job)
+
+
+@router.post(
+    "/workflow/bond_angle_scan",
+    response_model=JobResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def submit_bond_angle_scan(
+    scan: str = Form(...),
+    file: Optional[UploadFile] = File(None),
+    structure_id: Optional[str] = Form(None),
+    charge: int = Form(...),
+    multiplicity: int = Form(..., ge=1, le=4),
+    job_name: str = Form(...),
+    job_notes: Optional[str] = Form(None),
+    tags: List[str] = Form([]),
+    current_user=Depends(verify_token),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a bond, angle, or dihedral scan workflow job.
+
+    Provide exactly one molecule source: an XYZ file or an accessible
+    structure ID. `scan` is a JSON object describing the coordinate, its
+    1-based atom indices, whether other coordinates should relax, and either
+    explicit values or a min/max range with steps or spacing. The created job
+    is returned with `submitting` status and is processed asynchronously.
+
+    :param scan: JSON scan specification.
+    :param file: Molecule in XYZ format.
+    :param structure_id: ID of a stored molecule.
+    :param charge: Molecule charge.
+    :param multiplicity: Molecule multiplicity from 1 to 4.
+    :param job_name: Display name for the job.
+    :param job_notes: Notes for the job.
+    :param tags: Case-insensitive job tags.
+    :return: The created job.
+    """
+    try:
+        scan_spec = parse_scan_spec(scan, max_bytes=MAX_KEYWORDS_BYTES)
+    except ScanSpecValidationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid scan specification: {error}",
+        ) from error
+
+    user = get_user_or_404(db, get_user_sub(current_user))
+    job = create_calculation_job(
+        db,
+        user,
+        source_file=file,
+        structure_id=structure_id,
+        keywords_file=None,
+        keyword_values=scan_spec,
+        job_name=job_name,
+        job_notes=job_notes,
+        tags=tags,
+        calculation_type=CalculationType.scan,
+        method=SCAN_WORKFLOW_METHOD,
+        basis_set=SCAN_WORKFLOW_BASIS_SET,
+        charge=charge,
+        multiplicity=multiplicity,
     )
 
     return serialize_job(job)

--- a/calculation/routes.py
+++ b/calculation/routes.py
@@ -49,6 +49,7 @@ def submit_custom_calculation(
     job_name: str = Form(...),
     job_notes: Optional[str] = Form(None),
     tags: List[str] = Form([]),
+    upload_archive: bool = Form(True),
     current_user=Depends(verify_token),
     db: Session = Depends(get_db),
 ):
@@ -72,6 +73,7 @@ def submit_custom_calculation(
     :param job_name: Display name for the job.
     :param job_notes: Notes for the job.
     :param tags: Case-insensitive job tags.
+    :param upload_archive: Whether to request a ZIP archive for this job.
     :return: The created job.
     """
     if calculation_type == CalculationType.standard:
@@ -92,6 +94,7 @@ def submit_custom_calculation(
         job_name=job_name,
         job_notes=job_notes,
         tags=tags,
+        upload_archive=upload_archive,
         calculation_type=calculation_type,
         method=method,
         basis_set=basis_set,
@@ -117,6 +120,7 @@ def submit_standard_analysis(
     job_name: str = Form(...),
     job_notes: Optional[str] = Form(None),
     tags: List[str] = Form([]),
+    upload_archive: bool = Form(True),
     current_user=Depends(verify_token),
     db: Session = Depends(get_db),
 ):
@@ -135,6 +139,7 @@ def submit_standard_analysis(
     :param job_name: Display name for the job.
     :param job_notes: Notes for the job.
     :param tags: Case-insensitive job tags.
+    :param upload_archive: Whether to request a ZIP archive for this job.
     :return: The created job.
     """
     user = get_user_or_404(db, get_user_sub(current_user))
@@ -147,6 +152,7 @@ def submit_standard_analysis(
         job_name=job_name,
         job_notes=job_notes,
         tags=tags,
+        upload_archive=upload_archive,
         calculation_type=CalculationType.standard,
         method=STANDARD_ANALYSIS_METHOD,
         basis_set=STANDARD_ANALYSIS_BASIS_SET,
@@ -172,6 +178,7 @@ def submit_bond_angle_scan(
     job_name: str = Form(...),
     job_notes: Optional[str] = Form(None),
     tags: List[str] = Form([]),
+    upload_archive: bool = Form(True),
     current_user=Depends(verify_token),
     db: Session = Depends(get_db),
 ):
@@ -192,6 +199,7 @@ def submit_bond_angle_scan(
     :param job_name: Display name for the job.
     :param job_notes: Notes for the job.
     :param tags: Case-insensitive job tags.
+    :param upload_archive: Whether to request a ZIP archive for this job.
     :return: The created job.
     """
     try:
@@ -213,6 +221,7 @@ def submit_bond_angle_scan(
         job_name=job_name,
         job_notes=job_notes,
         tags=tags,
+        upload_archive=upload_archive,
         calculation_type=CalculationType.scan,
         method=SCAN_WORKFLOW_METHOD,
         basis_set=SCAN_WORKFLOW_BASIS_SET,

--- a/calculation/scan_spec.py
+++ b/calculation/scan_spec.py
@@ -1,0 +1,258 @@
+"""Parsing, validation, and normalization for scan specifications."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Mapping
+
+from ase.data import atomic_numbers
+
+
+class ScanSpecValidationError(ValueError):
+    """A scan specification cannot be safely submitted to the cluster."""
+
+
+COORDINATE_ATOM_COUNTS = {
+    "bond": 2,
+    "angle": 3,
+    "dihedral": 4,
+}
+
+
+def _reject_json_constant(_value: str) -> None:
+    raise ValueError
+
+
+def parse_scan_spec(value: str, *, max_bytes: int) -> dict[str, Any]:
+    """Parse a bounded JSON form field into a scan specification object."""
+
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ScanSpecValidationError(
+            "scan must contain a valid JSON object"
+        ) from error
+    if len(encoded) > max_bytes:
+        raise ScanSpecValidationError("scan is too large")
+
+    try:
+        scan_spec = json.loads(value, parse_constant=_reject_json_constant)
+    except (json.JSONDecodeError, ValueError) as error:
+        raise ScanSpecValidationError(
+            "scan must contain a valid JSON object"
+        ) from error
+    if not isinstance(scan_spec, dict):
+        raise ScanSpecValidationError("scan must contain a valid JSON object")
+    return scan_spec
+
+
+def _finite_number(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ScanSpecValidationError(f"{field_name} must be a finite number")
+    try:
+        finite = math.isfinite(value)
+    except (OverflowError, TypeError, ValueError):
+        finite = False
+    if not finite:
+        raise ScanSpecValidationError(f"{field_name} must be a finite number")
+    return float(value)
+
+
+def _validated_xyz_atom_count(input_xyz: str) -> int:
+    lines = input_xyz.splitlines()
+    try:
+        atom_count = int(lines[0].strip())
+    except (IndexError, TypeError, ValueError) as error:
+        raise ScanSpecValidationError(
+            "molecule must be valid XYZ text with an atom count"
+        ) from error
+    if atom_count < 1 or len(lines) < atom_count + 2:
+        raise ScanSpecValidationError(
+            "molecule must be valid XYZ text with an atom count"
+        )
+
+    for atom_number, line in enumerate(lines[2 : atom_count + 2], start=1):
+        fields = line.split()
+        if len(fields) < 4 or atomic_numbers.get(fields[0], 0) < 1:
+            raise ScanSpecValidationError(
+                f"molecule has an invalid XYZ atom row at atom {atom_number}"
+            )
+        try:
+            coordinates = [float(value) for value in fields[1:4]]
+        except ValueError as error:
+            raise ScanSpecValidationError(
+                f"molecule has an invalid XYZ atom row at atom {atom_number}"
+            ) from error
+        if not all(math.isfinite(value) for value in coordinates):
+            raise ScanSpecValidationError(
+                f"molecule has an invalid XYZ atom row at atom {atom_number}"
+            )
+    return atom_count
+
+
+def _validate_point_count(point_count: int, max_points: int) -> None:
+    if point_count > max_points:
+        raise ScanSpecValidationError(
+            f"scan must not contain more than {max_points} points"
+        )
+
+
+def _step_values(minimum: float, maximum: float, steps: int) -> list[float]:
+    span = maximum - minimum
+    if not math.isfinite(span):
+        raise ScanSpecValidationError("scan range is too large")
+    intervals = steps - 1
+    values = [minimum + span * (index / intervals) for index in range(steps)]
+    values[0] = minimum
+    values[-1] = maximum
+    return values
+
+
+def _spacing_values(
+    minimum: float,
+    maximum: float,
+    spacing: float,
+    *,
+    max_points: int,
+) -> list[float]:
+    span = maximum - minimum
+    if not math.isfinite(span):
+        raise ScanSpecValidationError("scan range is too large")
+
+    values = []
+    for index in range(max_points + 1):
+        offset = spacing * index
+        at_endpoint = math.isclose(offset, span, rel_tol=1e-12, abs_tol=0.0)
+        if offset > span and not at_endpoint:
+            break
+        values.append(maximum if at_endpoint else minimum + offset)
+
+    _validate_point_count(len(values), max_points)
+    if len(values) < 2:
+        raise ScanSpecValidationError("spacing must produce at least two scan points")
+    return values
+
+
+def _normalized_spec(
+    scan_spec: Mapping[str, Any],
+    *,
+    coordinate: str,
+    atoms: list[int],
+    relax: bool,
+    values: list[float],
+) -> dict[str, Any]:
+    normalized = dict(scan_spec)
+    for field in ("min", "max", "steps", "spacing"):
+        normalized.pop(field, None)
+    normalized.update(
+        coordinate=coordinate,
+        atoms=list(atoms),
+        relax=relax,
+        values=values,
+    )
+    return normalized
+
+
+def validate_scan_spec(
+    scan_spec: Mapping[str, Any],
+    *,
+    input_xyz: str,
+    max_points: int,
+) -> dict[str, Any]:
+    """Validate and normalize the cluster scan contract."""
+
+    coordinate = scan_spec.get("coordinate")
+    if not isinstance(coordinate, str) or coordinate not in COORDINATE_ATOM_COUNTS:
+        allowed = ", ".join(COORDINATE_ATOM_COUNTS)
+        raise ScanSpecValidationError(f"coordinate must be one of: {allowed}")
+
+    atoms = scan_spec.get("atoms")
+    expected_atoms = COORDINATE_ATOM_COUNTS[coordinate]
+    if not isinstance(atoms, list) or len(atoms) != expected_atoms:
+        raise ScanSpecValidationError(
+            f"{coordinate} scan requires exactly {expected_atoms} atoms"
+        )
+    if any(isinstance(atom, bool) or not isinstance(atom, int) for atom in atoms):
+        raise ScanSpecValidationError("atom indices must be integers")
+    if len(set(atoms)) != expected_atoms:
+        raise ScanSpecValidationError("atom indices must be distinct")
+
+    atom_count = _validated_xyz_atom_count(input_xyz)
+    if any(atom < 1 or atom > atom_count for atom in atoms):
+        raise ScanSpecValidationError(
+            f"atom indices must be between 1 and {atom_count}"
+        )
+
+    relax = scan_spec.get("relax", False)
+    if not isinstance(relax, bool):
+        raise ScanSpecValidationError("relax must be a boolean")
+
+    has_values = "values" in scan_spec
+    has_steps = "steps" in scan_spec
+    has_spacing = "spacing" in scan_spec
+    if sum((has_values, has_steps, has_spacing)) != 1:
+        raise ScanSpecValidationError(
+            "provide exactly one scan range: values, steps, or spacing"
+        )
+
+    if has_values:
+        if "min" in scan_spec or "max" in scan_spec:
+            raise ScanSpecValidationError("values cannot be combined with min or max")
+        values = scan_spec["values"]
+        if not isinstance(values, list) or len(values) < 2:
+            raise ScanSpecValidationError("values must contain at least two points")
+        _validate_point_count(len(values), max_points)
+        normalized_values = [_finite_number(value, "scan value") for value in values]
+        return _normalized_spec(
+            scan_spec,
+            coordinate=coordinate,
+            atoms=atoms,
+            relax=relax,
+            values=normalized_values,
+        )
+
+    if "min" not in scan_spec or "max" not in scan_spec:
+        raise ScanSpecValidationError("min and max are required for this range")
+    minimum = _finite_number(scan_spec["min"], "min")
+    maximum = _finite_number(scan_spec["max"], "max")
+    if minimum == maximum:
+        raise ScanSpecValidationError("min and max must be different")
+
+    if has_steps:
+        steps = scan_spec["steps"]
+        if isinstance(steps, bool) or not isinstance(steps, int) or steps < 2:
+            raise ScanSpecValidationError("steps must be an integer of at least 2")
+        _validate_point_count(steps, max_points)
+        return _normalized_spec(
+            scan_spec,
+            coordinate=coordinate,
+            atoms=atoms,
+            relax=relax,
+            values=_step_values(minimum, maximum, steps),
+        )
+
+    spacing = _finite_number(scan_spec["spacing"], "spacing")
+    if spacing <= 0:
+        raise ScanSpecValidationError("spacing must be greater than zero")
+    if maximum < minimum:
+        raise ScanSpecValidationError(
+            "max must be greater than min when spacing is used"
+        )
+    span = maximum - minimum
+    if not math.isfinite(span):
+        raise ScanSpecValidationError("scan range is too large")
+    if spacing > span:
+        raise ScanSpecValidationError("spacing must produce at least two scan points")
+    return _normalized_spec(
+        scan_spec,
+        coordinate=coordinate,
+        atoms=atoms,
+        relax=relax,
+        values=_spacing_values(
+            minimum,
+            maximum,
+            spacing,
+            max_points=max_points,
+        ),
+    )

--- a/deploy/systemd/molmaker-reconciler@.service
+++ b/deploy/systemd/molmaker-reconciler@.service
@@ -9,7 +9,7 @@ Type=simple
 User=backend
 Group=backend
 WorkingDirectory=/home/backend/molmaker_backend
-EnvironmentFile=/home/backend/.env
+Environment=BACKEND_ENV_FILE=/etc/molmaker/backend.env
 Environment=PYTHONUNBUFFERED=1
 ExecStart=/home/backend/env/bin/python -m orchestration.%i_reconciler
 Restart=on-failure

--- a/docs/backend-data-flow.md
+++ b/docs/backend-data-flow.md
@@ -15,7 +15,7 @@ endpoint schemas, use Swagger. For access rules, see
 | Reconciler processes | Submit jobs, poll Slurm, request cancellation, and finalise artifacts. |
 | Alliance dispatch | Accepts one validated JSON request per cluster operation and provides the restricted boundary to Slurm. |
 | Alliance job directory | Holds the input, script, logs, and results while a calculation is being processed. |
-| S3 | Stores ZIP archives uploaded during job finalisation. The backend exposes only archives paired with verified database results. |
+| S3 | Optionally stores ZIP archives uploaded during job finalisation. The backend exposes only archives explicitly recorded as uploaded. |
 
 ## Overall Flow
 
@@ -31,10 +31,11 @@ status. PostgreSQL is therefore the hand-off between separate operating-system
 processes, not an active coordinator.
 
 PostgreSQL is authoritative for identity, ownership, metadata, structures, job
-state, exact calculation inputs, results, and frontend artifacts. S3 stores only
-job ZIP archives. Alliance job directories are temporary working storage
-created from a submission request and removed after the backend saves the
-returned result and acknowledges cleanup.
+state, exact calculation inputs, results, frontend artifacts, and archive
+availability. When enabled, S3 stores only job ZIP archives. Alliance job
+directories are temporary working storage created from a submission request
+and removed after the backend saves the returned result and acknowledges
+cleanup.
 
 ## Authentication and Authorization
 
@@ -78,8 +79,10 @@ All calculation endpoints call `create_calculation_job`:
 3. Read and validate the bounded XYZ text. For a stored structure, read its
    PostgreSQL content and keep that exact text as the calculation snapshot.
 4. Parse the optional keywords file as a JSON object.
-5. Create the `jobs` row with `status=submitting`, ownership, tags, and at most
-   one linked source structure.
+5. Create the `jobs` row with `status=submitting`, the requested archive
+   preference, archive status `pending`, ownership, tags, and at most one
+   linked source structure. The optional multipart field `upload_archive`
+   defaults to `true`.
 6. Create the one-to-one `job_inputs` row with `input_xyz` and optional
    `keywords`.
 7. Commit the job, inputs, tags, and relationship together, then return
@@ -114,11 +117,13 @@ After creation, three processes use the job row as a durable queue:
 3. The status reconciler requests allocation states in batches and stores the
    public status and runtime.
 4. Terminal Slurm outcomes enter the internal `finalising` state.
-5. The finalisation reconciler creates one fresh S3 PUT URL for the ZIP and
-   sends it in a JSON upload request.
-6. The cluster uploads the ZIP and returns parsed results and frontend artifacts
-   through SSH stdout. The backend saves that content in PostgreSQL, makes the
-   external terminal result available, and then acknowledges cluster cleanup.
+5. The finalisation reconciler sends one fresh S3 PUT URL only when the global
+   archive switch is enabled and the job requested an archive. Otherwise it
+   sends JSON null.
+6. The cluster optionally uploads the ZIP and always returns parsed results and
+   frontend artifacts through SSH stdout. The backend saves that content and
+   the archive outcome in PostgreSQL, makes the external terminal result
+   available, and then acknowledges cluster cleanup.
    Scan jobs require the multi-frame `scan.xyz` artifact.
 7. Job endpoints return state, results, and artifacts from PostgreSQL. The
    archive endpoint authorizes the caller and creates the only presigned S3
@@ -135,7 +140,7 @@ stored content and thumbnail. Structure text is limited to 4 MiB. Thumbnails
 are limited to 8 MiB and must have both the `image/png` media type and PNG file
 signature before the backend stores them.
 
-S3 stores only the deterministic ZIP key below `S3_BUCKET_ROOT`:
+When enabled, S3 stores only the deterministic ZIP key below `S3_BUCKET_ROOT`:
 
 ```text
 {S3_BUCKET_ROOT}/archive/{job_id}.zip
@@ -143,7 +148,9 @@ S3 stores only the deterministic ZIP key below `S3_BUCKET_ROOT`:
 
 The API and reconcilers use the same S3 bucket settings. AWS credentials are
 not copied into backend settings; boto3 uses its standard credential provider
-chain.
+chain. With `ARCHIVE_UPLOAD_ENABLED=false` or `upload_archive=false`,
+finalisation does not instantiate an S3 client, create a URL, ZIP files, or
+perform an HTTP upload.
 
 Presigned URLs are short-lived capabilities:
 
@@ -155,7 +162,10 @@ Presigned URLs are short-lived capabilities:
 An archive can reach S3 before its matching database result is verified. If
 finalisation exhausts its attempts before saving that result, the backend does
 not expose the possibly uploaded ZIP. The archive becomes downloadable only
-after the matching result is validated and saved.
+after the matching result is validated and saved with
+`archive_uploaded=true`. Archive-disabled jobs still expose their saved result
+and frontend artifacts; their job response reports `archive_upload_status` as
+`disabled`, and the archive endpoint reports it unavailable.
 
 ## Ownership, Tags, and Lists
 
@@ -176,7 +186,8 @@ The complete permission matrix is in
 ## Process and Configuration Boundary
 
 The API, submission reconciler, status reconciler, and finalisation reconciler
-are four separate processes. Each imports `settings.py` and caches its own
+are four separate processes. Each loads the file selected by
+`BACKEND_ENV_FILE` (or the repository `.env` fallback) and caches its own
 validated `BackendSettings`, so environment changes require a restart.
 
 There is no in-memory queue or shared configuration process. PostgreSQL retains

--- a/docs/backend-data-flow.md
+++ b/docs/backend-data-flow.md
@@ -70,7 +70,7 @@ add owner email and group name for context.
 
 ## Calculation Creation
 
-Both calculation endpoints call `create_calculation_job`:
+All calculation endpoints call `create_calculation_job`:
 
 1. Validate and normalize calculation metadata.
 2. Require exactly one molecule source: an uploaded XYZ file or an accessible
@@ -84,6 +84,16 @@ Both calculation endpoints call `create_calculation_job`:
    `keywords`.
 7. Commit the job, inputs, tags, and relationship together, then return
    `201 Created`.
+
+`POST /calculation/workflow/bond_angle_scan` accepts the scan specification as
+a JSON multipart field. The backend validates its coordinate, 1-based atom
+indices, relaxation flag, value range, and XYZ atom rows. It enforces the
+backend-configured `MAX_SCAN_POINTS` limit and normalizes every range form to
+one explicit `values` list before storing it in `job_inputs.keywords`. The
+dedicated workflow fixes the level of theory at CCSD(T)/6-311+G(2d,p). A custom
+calculation may also use `calculation_type=scan`; in that case the scan
+specification comes from its required keywords JSON file and the caller-selected
+method and basis set are retained.
 
 If the save fails, the transaction rolls back all of those rows. Cluster
 submission and result-upload URL generation never run in the HTTP request.
@@ -109,6 +119,7 @@ After creation, three processes use the job row as a durable queue:
 6. The cluster uploads the ZIP and returns parsed results and frontend artifacts
    through SSH stdout. The backend saves that content in PostgreSQL, makes the
    external terminal result available, and then acknowledges cluster cleanup.
+   Scan jobs require the multi-frame `scan.xyz` artifact.
 7. Job endpoints return state, results, and artifacts from PostgreSQL. The
    archive endpoint authorizes the caller and creates the only presigned S3
    download URL.
@@ -179,7 +190,7 @@ the information needed for the next process or restarted worker to continue.
 | `auth.py` | Verifies Auth0 access tokens. |
 | `permissions.py` | Contains reusable permission predicates. |
 | `asset_service.py` | Lists, serializes, tags, transfers, and soft-deletes assets. |
-| `calculation/service.py` | Validates calculation inputs and saves jobs with `job_inputs`. |
+| `calculation/job_creation_service.py` | Validates calculation inputs and saves jobs with `job_inputs`. |
 | `jobs/routes.py` | Reads, edits, cancels, and soft-deletes jobs. |
 | `s3/routes.py` and `storage.py` | Authorize and create artifact URLs. |
 | `database.py` and `models.py` | Configure SQLAlchemy and define persistent data. |

--- a/docs/diagrams/backend-data-flow.svg
+++ b/docs/diagrams/backend-data-flow.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 710" role="img" aria-labelledby="title description">
   <title id="title">Backend request and data flow</title>
-  <desc id="description">Public requests pass through FastAPI authentication and permission checks to PostgreSQL. Structures, calculation inputs, results, and frontend artifacts are stored in PostgreSQL. Three reconcilers use one restricted JSON dispatch interface to run jobs on Alliance, save returned result data, and upload only ZIP archives to S3.</desc>
+  <desc id="description">Public requests pass through FastAPI authentication and permission checks to PostgreSQL. Structures, calculation inputs, results, frontend artifacts, and archive availability are stored in PostgreSQL. Three reconcilers use one restricted JSON dispatch interface to run jobs on Alliance, save returned result data, and optionally upload ZIP archives to S3.</desc>
 
   <defs>
     <filter id="shadow" x="-15%" y="-15%" width="130%" height="140%">
@@ -69,7 +69,7 @@
   <g filter="url(#shadow)">
     <rect x="1145" y="123" width="190" height="102" rx="10" fill="#eaf8f0" stroke="#159a62" stroke-width="1.8"/>
     <text class="node-title" x="1240" y="151" text-anchor="middle">S3</text>
-    <text class="node-body" x="1240" y="175" text-anchor="middle">ZIP archives only</text>
+    <text class="node-body" x="1240" y="175" text-anchor="middle">optional ZIP archives only</text>
     <text class="node-body" x="1240" y="197" text-anchor="middle">presigned downloads</text>
   </g>
 
@@ -78,7 +78,7 @@
   <path d="M650 174 H760" fill="none" stroke="#2563eb" stroke-width="4" marker-start="url(#arrow-blue)" marker-end="url(#arrow-blue)"/>
   <text class="action blue" x="705" y="158" text-anchor="middle">query / commit</text>
   <path d="M650 211 H700 V250 H1110 V211 H1145" fill="none" stroke="#159a62" stroke-width="3.1" marker-start="url(#arrow-green)" marker-end="url(#arrow-green)"/>
-  <text class="action green" x="905" y="244" text-anchor="middle">create fresh archive download URLs</text>
+  <text class="action green" x="905" y="244" text-anchor="middle">download URL when uploaded</text>
 
   <!-- Asynchronous calculation path. -->
   <rect x="25" y="315" width="1350" height="375" rx="16" fill="#ffffff" stroke="#c8d0dc" stroke-width="1.5"/>
@@ -120,7 +120,7 @@
     <text class="node-small" x="787" y="493" text-anchor="middle">inputs + recovery flag</text>
     <text class="node-body" x="787" y="524" text-anchor="middle">find-submission · status-batch · cancel</text>
     <text class="node-body" x="787" y="575" text-anchor="middle">upload-artifacts</text>
-    <text class="node-small" x="787" y="595" text-anchor="middle">one archive PUT URL · result response</text>
+    <text class="node-small" x="787" y="595" text-anchor="middle">archive URL/null · result response</text>
     <text class="node-small" x="787" y="629" text-anchor="middle">ack-finalisation after database save</text>
   </g>
 
@@ -160,7 +160,7 @@
   <text class="action indigo" x="952" y="516" text-anchor="middle">query</text>
 
   <path d="M595 607 H650" fill="none" stroke="#159a62" stroke-width="3.5" marker-end="url(#arrow-green)"/>
-  <text class="action green" x="622" y="591" text-anchor="middle">archive URL</text>
+  <text class="action green" x="622" y="591" text-anchor="middle">archive URL or null</text>
   <path d="M925 607 H980" fill="none" stroke="#159a62" stroke-width="3.5" marker-end="url(#arrow-green)"/>
   <text class="action green" x="952" y="591" text-anchor="middle">finalise</text>
   <path d="M1200 520 H1250" fill="none" stroke="#159a62" stroke-width="3.8" marker-end="url(#arrow-green)"/>

--- a/docs/diagrams/job-orchestration.svg
+++ b/docs/diagrams/job-orchestration.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 880" role="img" aria-labelledby="title description">
   <title id="title">Database-backed job orchestration</title>
-  <desc id="description">The API stores a submitting job and its exact calculation inputs in PostgreSQL. Three independent reconcilers use a restricted JSON dispatch command to submit and monitor Slurm jobs, upload one ZIP archive to S3, and save returned result data in PostgreSQL before acknowledging cleanup.</desc>
+  <desc id="description">The API stores a submitting job and its exact calculation inputs in PostgreSQL. Three independent reconcilers use a restricted JSON dispatch command to submit and monitor Slurm jobs, optionally upload one ZIP archive to S3, and save returned result data and archive availability in PostgreSQL before acknowledging cleanup.</desc>
 
   <defs>
     <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto">
@@ -77,7 +77,7 @@
   <text class="column-title" x="180" y="298" text-anchor="middle">RECONCILER</text>
   <text class="column-title" x="475" y="298" text-anchor="middle">VERSIONED JSON REQUEST</text>
   <text class="column-title" x="820" y="298" text-anchor="middle">RESTRICTED ALLIANCE DISPATCH</text>
-  <text class="column-title" x="1190" y="298" text-anchor="middle">SLURM OR S3</text>
+  <text class="column-title" x="1190" y="298" text-anchor="middle">SLURM / OPTIONAL S3</text>
 
   <!-- Database state bus. -->
   <path d="M1102 208 V230 H42 V771" fill="none" stroke="#4f78c8" stroke-width="2.3" stroke-dasharray="7 6"/>
@@ -168,7 +168,7 @@
   <g filter="url(#shadow)">
     <rect x="55" y="688" width="250" height="122" rx="11" fill="#eaf8f0" stroke="#159a62" stroke-width="2.3"/>
     <text class="node-title" x="180" y="717" text-anchor="middle">3. Finalisation reconciler</text>
-    <text class="node-body" x="180" y="749" text-anchor="middle">create one archive PUT URL</text>
+    <text class="node-body" x="180" y="749" text-anchor="middle">choose archive URL or null</text>
     <text class="node-body" x="180" y="774" text-anchor="middle">save result · acknowledge cleanup</text>
   </g>
 
@@ -176,20 +176,20 @@
     <rect x="355" y="688" width="240" height="122" rx="10" fill="#f4fbf7" stroke="#62b88f" stroke-width="1.7"/>
     <text class="node-title" x="475" y="717" text-anchor="middle">upload-artifacts</text>
     <text class="node-small" x="475" y="749" text-anchor="middle">job outcome + calculation type</text>
-    <text class="node-small" x="475" y="774" text-anchor="middle">archive URL · return result data</text>
+    <text class="node-small" x="475" y="774" text-anchor="middle">URL/null · return result data</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="660" y="688" width="320" height="122" rx="10" fill="#f4fbf7" stroke="#62b88f" stroke-width="1.8"/>
     <text class="node-title" x="820" y="717" text-anchor="middle">Alliance finalisation</text>
-    <text class="node-small" x="820" y="749" text-anchor="middle">upload ZIP · return result content</text>
+    <text class="node-small" x="820" y="749" text-anchor="middle">optional ZIP · return result content</text>
     <text class="node-small" x="820" y="774" text-anchor="middle">keep scratch until backend ack</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="1060" y="688" width="260" height="122" rx="10" fill="#eaf8f0" stroke="#159a62" stroke-width="1.9"/>
     <text class="node-title" x="1190" y="717" text-anchor="middle">S3 object storage</text>
-    <text class="node-small" x="1190" y="749" text-anchor="middle">one job ZIP archive</text>
+    <text class="node-small" x="1190" y="749" text-anchor="middle">optional job ZIP archive</text>
     <text class="node-small" x="1190" y="774" text-anchor="middle">one deterministic object key</text>
   </g>
 
@@ -199,7 +199,7 @@
   <text class="action green" x="627" y="717" text-anchor="middle">send request</text>
   <text class="command" x="627" y="786" text-anchor="middle">SSH stdin</text>
   <path d="M980 749 H1060" fill="none" stroke="#159a62" stroke-width="3.5" marker-end="url(#arrow-green)"/>
-  <text class="action green" x="1020" y="717" text-anchor="middle">upload archive</text>
+  <text class="action green" x="1020" y="717" text-anchor="middle">upload when enabled</text>
   <text class="command" x="1020" y="786" text-anchor="middle">presigned HTTPS PUT</text>
 
 </svg>

--- a/docs/job-orchestration.md
+++ b/docs/job-orchestration.md
@@ -57,6 +57,12 @@ On the cluster, `dispatch.py`:
 3. writes `input.xyz`, optional `keywords.json`, and `slurm.sh`; and
 4. runs `sbatch --parsable` and returns the Slurm ID.
 
+For `calculation_type=scan`, the required keywords object is the validated scan
+specification with a backend-generated explicit `values` list. Dispatch stages
+it as `keywords.json` and invokes the cluster's bond/angle/dihedral scan runner
+with the job's saved method and basis set. The cluster consumes that list
+directly, so it does not independently expand `steps` or `spacing` ranges.
+
 The backend saves that ID and changes the job to `submitted`. If `sbatch` may
 have succeeded but its response was lost, the next attempt searches first and
 does not create a duplicate when the existing job is found.
@@ -122,6 +128,8 @@ being treated as a shared cluster outage.
 The archive keeps available inputs, outputs, Slurm logs, and partial results.
 The result and artifact endpoints serve the verified PostgreSQL data directly,
 while the archive endpoint creates the only presigned S3 download URL.
+Completed scan jobs expose their parsed point data through the normal result
+endpoint and their multi-frame geometry through the `scan` artifact endpoint.
 
 The ZIP upload happens before the backend validates and saves the returned
 data. If validation or persistence repeatedly fails until `MAX_ATTEMPTS`, the

--- a/docs/job-orchestration.md
+++ b/docs/job-orchestration.md
@@ -21,7 +21,7 @@ use Swagger. For the surrounding backend components, see
 
 *Figure 1. PostgreSQL retains the job state and calculation inputs. The cluster
 stages its own job directory from the submission request, Slurm runs the
-calculation, and finalisation sends fresh upload URLs directly in JSON.*
+calculation, and finalisation sends an archive URL or JSON null directly.*
 
 ## Job States
 
@@ -30,8 +30,8 @@ calculation, and finalisation sends fresh upload URLs directly in JSON.*
 | `submitting` | `submitting` | The job and its database-backed inputs exist, but no accepted Slurm job is saved. |
 | `submitted` | `submitted` | Slurm accepted the job and it is waiting to run. |
 | `running` | `running` | Slurm reports an active state. |
-| `finalising` | `running` | Slurm finished and its files are being uploaded. |
-| `completed` | `completed` | Successful files are ready. |
+| `finalising` | `running` | Slurm finished and results are being collected; archive upload and cleanup may still be pending. |
+| `completed` | `completed` | Successful result data is ready. |
 | `failed` | `failed` | The calculation, cluster, or orchestration failed. |
 | `cancelled` | `cancelled` | Cancellation was confirmed and finalisation finished. |
 
@@ -104,15 +104,18 @@ terminal.
 
 ### 3. Finalisation
 
-The finalisation reconciler creates one fresh presigned PUT URL for the job's
-deterministic ZIP key and sends it in an `upload-artifacts` JSON request. The
-cluster builds and uploads the ZIP, then returns parsed result/error data and
-the required frontend artifacts through SSH stdout. Those returned files are
-stored in PostgreSQL; only the ZIP is stored in S3.
+`ARCHIVE_UPLOAD_ENABLED` is the deployment-wide master switch. Each submission
+also accepts optional multipart field `upload_archive`, which defaults to
+`true` and is saved with the job. The finalisation reconciler creates one fresh
+presigned PUT URL only when both values are true. Otherwise it does not create
+an S3 client or URL and sends JSON null. The cluster always returns parsed
+result/error data and required frontend artifacts through SSH stdout. It
+creates and uploads the ZIP only when it receives a URL.
 
 The cluster keeps the Alliance job directory until the backend validates and
-commits the complete `job_results` row. The backend then marks the result data
-and external terminal status available, sends `ack-finalisation`, and replaces
+commits the complete `job_results` row and archive outcome. The backend then
+marks the result data and external terminal status available, sends
+`ack-finalisation`, and replaces
 the internal `finalising` state with the terminal state after cleanup succeeds.
 If acknowledgement fails, the next attempt retries cleanup without
 transferring or saving the result again. A job-specific cleanup failure is
@@ -125,9 +128,13 @@ The complete cluster response is limited to 64 MiB. Exceeding that bound is a
 job-specific failure, so it consumes this job's attempt budget instead of
 being treated as a shared cluster outage.
 
-The archive keeps available inputs, outputs, Slurm logs, and partial results.
-The result and artifact endpoints serve the verified PostgreSQL data directly,
-while the archive endpoint creates the only presigned S3 download URL.
+`is_uploaded` continues to mean that structured PostgreSQL results are ready.
+The job response's `upload_archive` value reports the saved request.
+`archive_uploaded` independently records whether the ZIP exists, while
+`archive_upload_status` is `pending`, `disabled`, `uploaded`, or `unavailable`.
+The result and artifact endpoints depend only on the saved result. The archive
+endpoint requires `archive_uploaded=true` before creating a presigned download
+URL.
 Completed scan jobs expose their parsed point data through the normal result
 endpoint and their multi-frame geometry through the `scan` artifact endpoint.
 
@@ -135,16 +142,15 @@ The ZIP upload happens before the backend validates and saves the returned
 data. If validation or persistence repeatedly fails until `MAX_ATTEMPTS`, the
 job becomes `failed` with `result_upload_failed`. The backend does not expose a
 possibly uploaded ZIP from that incomplete attempt because no verified result
-was saved. Not every terminal job therefore has a downloadable archive; jobs
-cancelled before submission and jobs whose archive upload fails also do not.
-Until verified result data is ready, result, artifact, and archive endpoints
-return `409`.
+was saved. Disabling archive upload does not change a job's completed, failed,
+or cancelled calculation outcome. Result and artifact endpoints remain
+available, while the archive endpoint returns `409` without contacting S3.
 
 ## Retries, Outages, and Cancellation
 
 - A job-specific retryable failure increments that job's `attempt_count`; a
   successful stage resets it. Invalid job data can fail immediately.
-- A shared PostgreSQL, SSH, Slurm, or S3 failure stops the round without
+- A shared PostgreSQL, SSH, Slurm, or enabled-S3 failure stops the round without
   consuming attempts for every affected job. The process exponentially backs
   off up to the configured maximum and resets after recovery.
 - Polling intervals are measured from the start of one round to the next, and
@@ -165,21 +171,26 @@ itself should stop.
 
 ## Configuration and Deployment
 
-[`.env.example`](../.env.example) is the backend settings reference. Each API
-or reconciler process caches its own validated settings, so restart affected
-processes after an environment change.
+[`.env.example`](../.env.example) is the backend settings reference.
+`BACKEND_ENV_FILE` may select an absolute file from the process launcher; the
+repository `.env` is the fallback. Each API or reconciler process caches its
+own validated settings, so restart affected processes after a change.
 
 The backend runs exactly one submission, status, and finalisation process.
-Installation, migration, deployment, and operational commands are in the
+Installation, database reset, deployment, and operational commands are in the
 [README](../README.md#4-start-the-api-and-reconcilers).
 
 ## Restricted Alliance Dispatch
 
-The backend connects through the `cluster` SSH alias. Its key can invoke only
-the fixed no-argument `dispatch.py` command; the requested operation is inside
-validated JSON, not in the remote shell command. The canonical cluster sources
-are the files in the reviewed `Cluster-API-QC` repository checkout, including
-the dispatch runner, protocol, calculation code, and artifact uploader.
+The backend connects through `CLUSTER_SSH_HOST` and invokes the exact
+`CLUSTER_DISPATCH_PATH`. Its key can invoke only that no-argument dispatcher;
+the requested operation is inside validated JSON, not in the remote shell
+command. That restricted command's Python runs the dispatcher and uploader.
+Each generated Slurm script separately activates
+`SLURM_ENV_ACTIVATION_COMMAND` and invokes plain `python`, so calculations use
+the activated environment. The canonical cluster sources are the files in the
+reviewed `Cluster-API-QC` repository checkout, including the dispatch runner,
+protocol, calculation code, and artifact uploader.
 
 | JSON command | Cluster action |
 |---|---|
@@ -187,7 +198,7 @@ the dispatch runner, protocol, calculation code, and artifact uploader.
 | `find-submission` | Search exact job names with `squeue`, then the last 24 hours of `sacct`; never submit. |
 | `status-batch` | Run one allocation-only `sacct` query for a batch of Slurm IDs. |
 | `cancel` | Run repeat-safe `scancel --quiet`. |
-| `upload-artifacts` | Pass one fresh archive PUT URL, upload the ZIP, and return database-bound result data without deleting scratch. |
+| `upload-artifacts` | Pass an archive PUT URL or null, optionally upload the ZIP, and always return database-bound result data without deleting scratch. |
 | `ack-finalisation` | Delete the validated job directory after the backend has saved the result. |
 
 The matching repository commit must be deployed before the reconcilers are

--- a/docs/ownership-and-permissions.md
+++ b/docs/ownership-and-permissions.md
@@ -183,16 +183,17 @@ Request history cleanup after user or group deletion is described in
 
 Permission to read a job also controls access to its related data:
 
-- fresh links for individually available S3 artifacts from
-  `GET /storage/jobs/{job_id}`
-- the S3 archive link from `GET /storage/jobs/{job_id}/archive`
+- parsed results and retained frontend artifacts from the `/jobs/{job_id}`
+  result and artifact endpoints; and
+- the optional S3 archive link from `GET /storage/jobs/{job_id}/archive`.
 
 An endpoint that exposes new job files or results must use the same job read
 permission. Checking only that the caller is authenticated is not enough.
 
-Both endpoints require a publicly terminal job whose files finished uploading.
-They return `409` while files are unavailable. Soft-deleted jobs are hidden and
-therefore cannot be used to fetch artifact links through the API.
+Result endpoints require saved PostgreSQL result data. Archive download also
+requires `archive_uploaded=true`; disabled or unavailable archives return `409`
+without hiding the result. Soft-deleted jobs are hidden and therefore cannot be
+used to fetch result or archive data through the API.
 
 ## User and Group Management
 

--- a/enum_types.py
+++ b/enum_types.py
@@ -34,6 +34,13 @@ class JobFailureReason(str, Enum):
     unknown = "unknown"
 
 
+class ArchiveUploadStatus(str, Enum):
+    pending = "pending"
+    disabled = "disabled"
+    uploaded = "uploaded"
+    unavailable = "unavailable"
+
+
 class AssetOwnership(str, Enum):
     user = "user"
     group = "group"

--- a/enum_types.py
+++ b/enum_types.py
@@ -6,6 +6,7 @@ class CalculationType(str, Enum):
     geometry = "optimization"
     orbitals = "orbitals"
     frequency = "frequency"
+    scan = "scan"
     standard = "standard"
     transition = "transition"
     irc = "irc"
@@ -58,6 +59,7 @@ calculation_types = {
     "Geometric Optimization": "optimization",
     "Vibrational Frequency": "frequency",
     "Molecular Orbitals": "orbitals",
+    "Bond/Angle Scan": "scan",
     "Standard Analysis": "standard",
     "Transition State Optimization": "transition",
     "Intrinsic Reaction Coordinate": "irc",

--- a/jobs/schemas.py
+++ b/jobs/schemas.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from enum_types import CalculationType, JobFailureReason
+from enum_types import ArchiveUploadStatus, CalculationType, JobFailureReason
 from structures.schemas import StructureResponse
 
 
@@ -41,6 +41,9 @@ class JobResponse(BaseModel):
     cancel_requested: bool
     failure_reason: Optional[JobFailureReason] = None
     failure_message: Optional[str] = None
+    upload_archive: bool
+    archive_uploaded: bool
+    archive_upload_status: ArchiveUploadStatus
     tags: List[str]
     structures: List[StructureResponse]
 

--- a/models.py
+++ b/models.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import (
 )
 
 from database import Base
+from enum_types import ArchiveUploadStatus
 
 jobs_structures = Table(
     "jobs_structures",
@@ -150,6 +151,12 @@ class Job(Asset):
             "is_deleted OR user_sub IS NOT NULL OR group_id IS NOT NULL",
             name="ck_jobs_owner_present",
         ),
+        CheckConstraint(
+            "archive_upload_status IN "
+            "('pending', 'disabled', 'uploaded', 'unavailable') "
+            "AND archive_uploaded = (archive_upload_status = 'uploaded')",
+            name="ck_jobs_archive_upload_state",
+        ),
         UniqueConstraint("slurm_id", name="uq_jobs_slurm_id"),
         Index(
             "idx_jobs_user_active_submitted", "user_sub", "is_deleted", "submitted_at"
@@ -183,6 +190,24 @@ class Job(Asset):
     slurm_id = Column(String, nullable=True)
     runtime = Column(Interval, nullable=True)
     is_uploaded = Column(Boolean, nullable=False)
+    archive_upload_requested = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("true"),
+    )
+    archive_uploaded = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
+    archive_upload_status = Column(
+        String,
+        nullable=False,
+        default=ArchiveUploadStatus.pending.value,
+        server_default=text("'pending'"),
+    )
     attempt_count = Column(
         Integer,
         nullable=False,

--- a/orchestration/cluster_client.py
+++ b/orchestration/cluster_client.py
@@ -11,9 +11,8 @@ from typing import Any, Iterable, Literal
 from uuid import UUID
 
 from enum_types import CalculationType, JobStatus
-from settings import BackendSettings
+from settings import OrchestrationSettings
 
-SSH_HOST = "cluster"
 PROTOCOL_VERSION = 1
 MAX_CLUSTER_RESPONSE_BYTES = 64 * 1024 * 1024
 COMMAND_REJECTION = "Command rejected by allowed_commands.sh"
@@ -84,8 +83,9 @@ class SlurmJobStatus:
 
 @dataclass(frozen=True)
 class FinalisationResult:
-    """Validated database-bound data returned after the archive upload."""
+    """Validated database-bound data returned after artifact finalisation."""
 
+    archive_uploaded: bool
     calculation_result: dict[str, Any] | None
     calculation_error: dict[str, Any] | None
     artifacts: dict[str, str]
@@ -135,12 +135,16 @@ def _finalisation_result(
     result: dict[str, Any],
     *,
     expected_job_id: str,
+    archive_requested: bool,
 ) -> FinalisationResult:
     """Validate the transport-level finalisation response."""
 
     if result["job_id"] != expected_job_id:
         raise ClusterServiceError(INVALID_FINALISATION_RESPONSE)
-    if result["archive_uploaded"] is not True:
+    archive_uploaded = result["archive_uploaded"]
+    if type(archive_uploaded) is not bool:
+        raise ClusterServiceError(INVALID_FINALISATION_RESPONSE)
+    if not archive_requested and archive_uploaded:
         raise ClusterServiceError(INVALID_FINALISATION_RESPONSE)
     calculation_result = result["calculation_result"]
     calculation_error = result["calculation_error"]
@@ -167,6 +171,7 @@ def _finalisation_result(
             raise ClusterServiceError(INVALID_FINALISATION_RESPONSE) from None
 
     return FinalisationResult(
+        archive_uploaded=archive_uploaded,
         calculation_result=calculation_result,
         calculation_error=calculation_error,
         artifacts=dict(artifacts),
@@ -220,20 +225,22 @@ def _status_from_row(row: Any) -> SlurmJobStatus:
 class ClusterDispatchClient:
     """Send JSON requests to the cluster and validate their responses."""
 
-    cluster_work_dir: PurePosixPath
+    ssh_host: str
+    dispatch_path: PurePosixPath
     timeout_seconds: int
     storage_timeout_seconds: int
 
     @classmethod
     def from_settings(
         cls,
-        settings: BackendSettings,
+        settings: OrchestrationSettings,
     ) -> "ClusterDispatchClient":
-        orchestration = settings.orchestration
+        ssh_host, dispatch_path = settings.require_cluster_dispatch()
         return cls(
-            settings.require_cluster_work_dir(),
-            orchestration.slurm_command_timeout_seconds,
-            orchestration.storage_operation_timeout_seconds,
+            ssh_host,
+            dispatch_path,
+            settings.slurm_command_timeout_seconds,
+            settings.storage_operation_timeout_seconds,
         )
 
     def submit_job(
@@ -332,7 +339,7 @@ class ClusterDispatchClient:
         job_id: UUID | str,
         calculation_type: CalculationType,
         terminal_status: JobStatus,
-        archive_upload_url: str,
+        archive_upload_url: str | None,
         allow_missing_error: bool = False,
     ) -> FinalisationResult:
         """Upload one archive and return the content destined for PostgreSQL."""
@@ -350,7 +357,11 @@ class ClusterDispatchClient:
             "artifact finalisation",
             timeout_seconds=self.storage_timeout_seconds,
         )
-        return _finalisation_result(result, expected_job_id=normalized_job_id)
+        return _finalisation_result(
+            result,
+            expected_job_id=normalized_job_id,
+            archive_requested=archive_upload_url is not None,
+        )
 
     def acknowledge_finalisation(self, job_id: UUID | str) -> None:
         """Acknowledge a committed result so cluster cleanup can be repeated."""
@@ -394,13 +405,10 @@ class ClusterDispatchClient:
                 ) from None
             raise ValueError(f"Cluster {operation} request is invalid") from None
 
-        dispatch_path = (
-            self.cluster_work_dir / "Cluster-API-QC" / "runner" / "dispatch.py"
-        )
-        remote_command = shlex.join(["python3", str(dispatch_path)])
+        remote_command = shlex.join(["python3", str(self.dispatch_path)])
         try:
             completed = subprocess.run(
-                ["ssh", SSH_HOST, remote_command],
+                ["ssh", self.ssh_host, remote_command],
                 input=input_text,
                 check=False,
                 capture_output=True,

--- a/orchestration/finalisation_reconciler.py
+++ b/orchestration/finalisation_reconciler.py
@@ -11,9 +11,18 @@ from typing import Callable, Sequence
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
-from asset_service import JobResultValidationError, upsert_job_result
+from asset_service import (
+    JobResultValidationError,
+    set_job_archive_outcome,
+    upsert_job_result,
+)
 from database import get_session_local
-from enum_types import CalculationType, JobFailureReason, JobStatus
+from enum_types import (
+    ArchiveUploadStatus,
+    CalculationType,
+    JobFailureReason,
+    JobStatus,
+)
 from models import Job
 from orchestration.base_reconciler import BaseReconciler
 from orchestration.cluster_client import (
@@ -51,6 +60,7 @@ class FinalisationReconciler(BaseReconciler):
     session_factory: Callable[[], Session]
     cluster_client: ClusterDispatchClient
     settings: OrchestrationSettings
+    archive_upload_enabled: bool
     generate_upload_url: Callable[[str], str] = generate_archive_upload_url
     sleep: Callable[[float], None] = time.sleep
     clock: Callable[[], float] = time.monotonic
@@ -61,8 +71,9 @@ class FinalisationReconciler(BaseReconciler):
         settings = backend_settings.orchestration
         return cls(
             session_factory=get_session_local(),
-            cluster_client=ClusterDispatchClient.from_settings(backend_settings),
+            cluster_client=ClusterDispatchClient.from_settings(settings),
             settings=settings,
+            archive_upload_enabled=backend_settings.archive_upload_enabled,
         )
 
     @property
@@ -97,7 +108,9 @@ class FinalisationReconciler(BaseReconciler):
 
         result_was_saved = False
         if job.job_result is None:
-            archive_upload_url = self.generate_upload_url(str(job.job_id))
+            archive_upload_url = None
+            if self.archive_upload_enabled and job.archive_upload_requested:
+                archive_upload_url = self.generate_upload_url(str(job.job_id))
             try:
                 result = self._upload_artifacts(
                     job,
@@ -105,12 +118,21 @@ class FinalisationReconciler(BaseReconciler):
                     terminal_status,
                     archive_upload_url,
                 )
+                archive_upload_status = self._archive_upload_status(
+                    archive_upload_url,
+                    result.archive_uploaded,
+                )
                 upsert_job_result(
                     db,
                     job,
                     result=result.calculation_result,
                     error=result.calculation_error,
                     artifacts=result.artifacts,
+                )
+                set_job_archive_outcome(
+                    job,
+                    archive_uploaded=result.archive_uploaded,
+                    archive_upload_status=archive_upload_status,
                 )
                 result_was_saved = True
             except (JobDispatchError, JobResultValidationError) as error:
@@ -137,7 +159,7 @@ class FinalisationReconciler(BaseReconciler):
         job: Job,
         calculation_type: CalculationType,
         terminal_status: JobStatus,
-        archive_upload_url: str,
+        archive_upload_url: str | None,
     ) -> FinalisationResult:
         return self.cluster_client.upload_artifacts(
             job_id=job.job_id,
@@ -149,6 +171,21 @@ class FinalisationReconciler(BaseReconciler):
                 and job.failure_reason != JobFailureReason.calculation_failed.value
             ),
         )
+
+    @staticmethod
+    def _archive_upload_status(
+        archive_upload_url: str | None,
+        archive_uploaded: bool,
+    ) -> ArchiveUploadStatus:
+        if archive_upload_url is None:
+            if archive_uploaded:
+                raise JobResultValidationError(
+                    "Cluster reported an upload without an archive destination"
+                )
+            return ArchiveUploadStatus.disabled
+        if archive_uploaded:
+            return ArchiveUploadStatus.uploaded
+        return ArchiveUploadStatus.unavailable
 
     def _record_job_failure(self, db: Session, job: Job, message: str) -> None:
         job.attempt_count += 1

--- a/orchestration/status_reconciler.py
+++ b/orchestration/status_reconciler.py
@@ -136,7 +136,7 @@ class StatusReconciler(BaseReconciler):
         settings = backend_settings.orchestration
         return cls(
             session_factory=get_session_local(),
-            cluster_client=ClusterDispatchClient.from_settings(backend_settings),
+            cluster_client=ClusterDispatchClient.from_settings(settings),
             settings=settings,
         )
 

--- a/orchestration/submission_reconciler.py
+++ b/orchestration/submission_reconciler.py
@@ -49,7 +49,7 @@ class SubmissionReconciler(BaseReconciler):
         settings = backend_settings.orchestration
         return cls(
             session_factory=get_session_local(),
-            cluster_client=ClusterDispatchClient.from_settings(backend_settings),
+            cluster_client=ClusterDispatchClient.from_settings(settings),
             settings=settings,
         )
 

--- a/s3/routes.py
+++ b/s3/routes.py
@@ -33,11 +33,16 @@ class JobArchiveResponse(BaseModel):
     url: str
 
 
-def _require_job_files_ready(job: Job) -> None:
+def _require_job_archive_ready(job: Job) -> None:
     if not is_job_result_ready(job):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Job files are not ready",
+            detail="Job archive is not ready",
+        )
+    if not job.archive_uploaded:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Job archive is unavailable",
         )
 
 
@@ -45,7 +50,9 @@ def _require_job_files_ready(job: Job) -> None:
     "/jobs/{job_id}/archive",
     response_model=JobArchiveResponse,
     responses={
-        status.HTTP_409_CONFLICT: {"description": "Job files are not ready."},
+        status.HTTP_409_CONFLICT: {
+            "description": "Job archive is not ready or unavailable."
+        },
         status.HTTP_503_SERVICE_UNAVAILABLE: {
             "description": "File storage is temporarily unavailable."
         },
@@ -67,7 +74,7 @@ def get_job_archive(
     job = get_asset_or_404(db, Job, job_id)
     user = get_user_or_404(db, get_user_sub(current_user))
     require_asset_permission(user, job, can_read_asset)
-    _require_job_files_ready(job)
+    _require_job_archive_ready(job)
 
     try:
         url = presign_zip_download_url(str(job.job_id))

--- a/settings.py
+++ b/settings.py
@@ -36,6 +36,10 @@ APPLICATION_DEFAULTS = {
     "S3_BUCKET_ROOT": "ubchemica",
 }
 
+CALCULATION_DEFAULTS = {
+    "MAX_SCAN_POINTS": 200,
+}
+
 SUPPORTED_ENVIRONMENT_VARIABLES = frozenset(
     {
         "DATABASE_USER",
@@ -49,11 +53,13 @@ SUPPORTED_ENVIRONMENT_VARIABLES = frozenset(
         "AUTH0_CLIENT_SECRET",
         "CLUSTER_WORK_DIR",
         *APPLICATION_DEFAULTS,
+        *CALCULATION_DEFAULTS,
         *ORCHESTRATION_DEFAULTS,
     }
 )
 
 MAX_STATUS_BATCH_SIZE = 1_000
+MAX_CONFIGURED_SCAN_POINTS = 10_000
 MIN_SLURM_JOB_TIME_LIMIT_MINUTES = 1
 MAX_SLURM_JOB_TIME_LIMIT_MINUTES = 7 * 24 * 60
 MIN_SLURM_JOB_MEMORY_MB = 256
@@ -145,6 +151,7 @@ class BackendSettings:
     s3_bucket_name: str
     s3_region: str
     s3_bucket_root: str
+    max_scan_points: int
     orchestration: OrchestrationSettings
 
     @classmethod
@@ -161,6 +168,13 @@ class BackendSettings:
         s3_bucket_root = _text_with_default("S3_BUCKET_ROOT").strip("/")
         if not s3_bucket_root:
             raise ValueError("S3_BUCKET_ROOT must not be empty")
+
+        max_scan_points = _bounded_positive_integer(
+            "MAX_SCAN_POINTS",
+            CALCULATION_DEFAULTS["MAX_SCAN_POINTS"],
+            2,
+            MAX_CONFIGURED_SCAN_POINTS,
+        )
 
         orchestration = OrchestrationSettings(
             submission_poll_interval_seconds=_positive_integer(
@@ -250,6 +264,7 @@ class BackendSettings:
             s3_bucket_name=_text_with_default("S3_BUCKET_NAME"),
             s3_region=_text_with_default("S3_REGION"),
             s3_bucket_root=s3_bucket_root,
+            max_scan_points=max_scan_points,
             orchestration=orchestration,
         )
 

--- a/settings.py
+++ b/settings.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 from dotenv import load_dotenv
 from sqlalchemy.engine import URL
 
-load_dotenv()
-
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_ENV_FILE = PROJECT_ROOT / ".env"
+ENV_FILE_VARIABLE = "BACKEND_ENV_FILE"
 
 ORCHESTRATION_DEFAULTS = {
     "SUBMISSION_POLL_INTERVAL_SECONDS": 5,
@@ -31,6 +33,7 @@ ORCHESTRATION_DEFAULTS = {
 
 APPLICATION_DEFAULTS = {
     "ALGORITHMS": "RS256",
+    "ARCHIVE_UPLOAD_ENABLED": "true",
     "S3_BUCKET_NAME": "ubchemica-bucket-1",
     "S3_REGION": "ca-central-1",
     "S3_BUCKET_ROOT": "ubchemica",
@@ -51,7 +54,8 @@ SUPPORTED_ENVIRONMENT_VARIABLES = frozenset(
         "API_AUDIENCE",
         "AUTH0_CLIENT_ID",
         "AUTH0_CLIENT_SECRET",
-        "CLUSTER_WORK_DIR",
+        "CLUSTER_SSH_HOST",
+        "CLUSTER_DISPATCH_PATH",
         *APPLICATION_DEFAULTS,
         *CALCULATION_DEFAULTS,
         *ORCHESTRATION_DEFAULTS,
@@ -64,6 +68,36 @@ MIN_SLURM_JOB_TIME_LIMIT_MINUTES = 1
 MAX_SLURM_JOB_TIME_LIMIT_MINUTES = 7 * 24 * 60
 MIN_SLURM_JOB_MEMORY_MB = 256
 MAX_SLURM_JOB_MEMORY_MB = 256 * 1024
+
+
+class BackendConfigurationError(ValueError):
+    """Backend configuration is missing or invalid."""
+
+
+def _configured_env_file(environ: Mapping[str, str]) -> Path | None:
+    configured = environ.get(ENV_FILE_VARIABLE)
+    if configured is None:
+        return DEFAULT_ENV_FILE if DEFAULT_ENV_FILE.is_file() else None
+    if not configured.strip():
+        raise BackendConfigurationError(f"{ENV_FILE_VARIABLE} must not be empty")
+
+    path = Path(configured.strip())
+    if not path.is_absolute():
+        raise BackendConfigurationError(f"{ENV_FILE_VARIABLE} must be absolute")
+    if not path.is_file():
+        raise BackendConfigurationError(
+            f"{ENV_FILE_VARIABLE} must identify an existing regular file"
+        )
+    return path.resolve()
+
+
+def load_backend_environment() -> Path | None:
+    """Load the selected dotenv file without replacing process values."""
+
+    env_file = _configured_env_file(os.environ)
+    if env_file is not None:
+        load_dotenv(dotenv_path=env_file, override=False)
+    return env_file
 
 
 def _optional_text(name: str) -> str | None:
@@ -83,6 +117,40 @@ def _text_with_default(name: str) -> str:
     if not value:
         raise ValueError(f"{name} must not be empty")
     return value
+
+
+def _boolean(name: str, default: str) -> bool:
+    value = os.getenv(name, default).strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"{name} must be true or false")
+
+
+def _cluster_ssh_host() -> str | None:
+    host = _optional_text("CLUSTER_SSH_HOST")
+    if host is None:
+        return None
+    if (
+        host.startswith("-")
+        or "\x00" in host
+        or any(character.isspace() for character in host)
+    ):
+        raise ValueError("CLUSTER_SSH_HOST is invalid")
+    return host
+
+
+def _cluster_dispatch_path() -> PurePosixPath | None:
+    value = _optional_text("CLUSTER_DISPATCH_PATH")
+    if value is None:
+        return None
+    if "\x00" in value:
+        raise ValueError("CLUSTER_DISPATCH_PATH is invalid")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise ValueError("CLUSTER_DISPATCH_PATH must be an absolute path")
+    return path
 
 
 def _positive_integer(name: str, default: int | None = None) -> int | None:
@@ -133,6 +201,17 @@ class OrchestrationSettings:
         "SLURM_JOB_TIME_LIMIT_MINUTES"
     ]
     slurm_job_memory_mb: int = ORCHESTRATION_DEFAULTS["SLURM_JOB_MEMORY_MB"]
+    cluster_ssh_host: str | None = None
+    cluster_dispatch_path: PurePosixPath | None = None
+
+    def require_cluster_dispatch(self) -> tuple[str, PurePosixPath]:
+        _required(
+            {
+                "CLUSTER_SSH_HOST": self.cluster_ssh_host,
+                "CLUSTER_DISPATCH_PATH": self.cluster_dispatch_path,
+            }
+        )
+        return self.cluster_ssh_host, self.cluster_dispatch_path
 
 
 @dataclass(frozen=True)
@@ -147,7 +226,7 @@ class BackendSettings:
     algorithms: tuple[str, ...]
     auth0_client_id: str | None
     auth0_client_secret: str | None
-    cluster_work_dir: PurePosixPath | None
+    archive_upload_enabled: bool
     s3_bucket_name: str
     s3_region: str
     s3_bucket_root: str
@@ -164,7 +243,6 @@ class BackendSettings:
         if not algorithms:
             raise ValueError("ALGORITHMS must include at least one algorithm")
 
-        cluster_work_dir = _optional_text("CLUSTER_WORK_DIR")
         s3_bucket_root = _text_with_default("S3_BUCKET_ROOT").strip("/")
         if not s3_bucket_root:
             raise ValueError("S3_BUCKET_ROOT must not be empty")
@@ -233,6 +311,8 @@ class BackendSettings:
                 "STORAGE_OPERATION_TIMEOUT_SECONDS",
                 ORCHESTRATION_DEFAULTS["STORAGE_OPERATION_TIMEOUT_SECONDS"],
             ),
+            cluster_ssh_host=_cluster_ssh_host(),
+            cluster_dispatch_path=_cluster_dispatch_path(),
         )
         if (
             orchestration.outage_initial_backoff_seconds
@@ -258,8 +338,9 @@ class BackendSettings:
             algorithms=algorithms,
             auth0_client_id=_optional_text("AUTH0_CLIENT_ID"),
             auth0_client_secret=_optional_secret("AUTH0_CLIENT_SECRET"),
-            cluster_work_dir=(
-                PurePosixPath(cluster_work_dir) if cluster_work_dir else None
+            archive_upload_enabled=_boolean(
+                "ARCHIVE_UPLOAD_ENABLED",
+                APPLICATION_DEFAULTS["ARCHIVE_UPLOAD_ENABLED"],
             ),
             s3_bucket_name=_text_with_default("S3_BUCKET_NAME"),
             s3_region=_text_with_default("S3_REGION"),
@@ -307,13 +388,10 @@ class BackendSettings:
         _required({"AUTH0_DOMAIN": self.auth0_domain})
         return self.auth0_domain
 
-    def require_cluster_work_dir(self) -> PurePosixPath:
-        _required({"CLUSTER_WORK_DIR": self.cluster_work_dir})
-        return self.cluster_work_dir
-
 
 @cache
 def get_settings() -> BackendSettings:
     """Return one validated settings object for the current process."""
 
+    load_backend_environment()
     return BackendSettings.from_env()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from auth import verify_token
 from database import Base
 from dependencies import get_db
-from enum_types import JobStatus
+from enum_types import ArchiveUploadStatus, JobStatus
 from main import create_app
 from models import Group, Job, JobInput, JobResult, Request, Structure, Tags, User
 from settings import get_settings
@@ -281,6 +281,9 @@ def job_factory(db):
             "is_deleted": False,
             "is_public": False,
             "is_uploaded": False,
+            "archive_upload_requested": True,
+            "archive_uploaded": False,
+            "archive_upload_status": ArchiveUploadStatus.pending.value,
             "attempt_count": 0,
             "cancel_requested": False,
         }
@@ -309,6 +312,7 @@ def job_result_factory(db, job_factory):
         job = job or job_factory(
             status=JobStatus.completed.value,
             is_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.unavailable.value,
         )
         values = {
             "job_id": job.job_id,

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -18,6 +18,7 @@ LEGACY_OPERATIONS = {
 REPLACEMENT_OPERATIONS = {
     ("/calculation/custom", "post"),
     ("/calculation/workflow/standard_analysis", "post"),
+    ("/calculation/workflow/bond_angle_scan", "post"),
     ("/jobs/", "get"),
     ("/jobs/{job_id}", "get"),
     ("/jobs/{job_id}/cancel", "post"),

--- a/tests/test_asset_model.py
+++ b/tests/test_asset_model.py
@@ -69,6 +69,24 @@ class TestAssetModel:
         assert job.failure_reason is None
         assert job.failure_message is None
         assert job.optimization_type is None
+        assert job.archive_upload_requested is True
+        assert job.archive_uploaded is False
+        assert job.archive_upload_status == "pending"
+
+    def test_archive_upload_fields_must_remain_consistent(
+        self,
+        db,
+        user_factory,
+        job_factory,
+    ):
+        user_factory(user_sub="auth0|testuser")
+
+        with pytest.raises(IntegrityError):
+            job_factory(
+                archive_uploaded=True,
+                archive_upload_status="unavailable",
+            )
+        db.rollback()
 
     def test_job_has_partial_active_orchestration_index(self):
         index = next(

--- a/tests/test_asset_service.py
+++ b/tests/test_asset_service.py
@@ -216,6 +216,9 @@ class TestSerializeJob:
         assert result["group_id"] is None
         assert result["failure_reason"] is None
         assert result["failure_message"] is None
+        assert result["upload_archive"] is True
+        assert result["archive_uploaded"] is False
+        assert result["archive_upload_status"] == "pending"
         assert "slurm_id" not in result
 
     def test_maps_internal_status_and_returns_stored_failure_details(

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -103,7 +103,16 @@ def test_openapi_documents_durable_calculation_submission_contract(client):
         ]
         request_schema_name = request_schema["$ref"].rsplit("/", 1)[-1]
         request_properties = components[request_schema_name]["properties"]
-        assert {"file", "structure_id", "job_name"}.issubset(request_properties)
+        assert {
+            "file",
+            "structure_id",
+            "job_name",
+            "upload_archive",
+        }.issubset(request_properties)
+        assert request_properties["upload_archive"]["default"] is True
+        assert "upload_archive" not in components[request_schema_name].get(
+            "required", []
+        )
         if path.endswith("bond_angle_scan"):
             assert "scan" in request_properties
 
@@ -162,6 +171,7 @@ def test_custom_submission_persists_inputs_without_external_orchestration(
             job_name="  Optimise water  ",
             job_notes="  transition search  ",
             tags=["EXISTING", "New", "new"],
+            upload_archive="false",
         ),
         files={
             "file": (
@@ -190,6 +200,7 @@ def test_custom_submission_persists_inputs_without_external_orchestration(
     assert result["charge"] == -1
     assert result["multiplicity"] == 2
     assert result["optimization_type"] == "ts"
+    assert result["upload_archive"] is False
     assert result["user_sub"] == user.user_sub
     assert result["group_id"] == str(group.group_id)
     assert sorted(result["tags"]) == ["existing", "new"]
@@ -208,6 +219,7 @@ def test_custom_submission_persists_inputs_without_external_orchestration(
     assert job.attempt_count == 0
     assert job.cancel_requested is False
     assert job.is_uploaded is False
+    assert job.archive_upload_requested is False
     assert job.is_deleted is False
     assert job.is_public is False
     assert job.user_sub == user.user_sub
@@ -251,9 +263,11 @@ def test_standard_submission_uses_workflow_defaults(
     assert result["multiplicity"] == 2
     assert result["optimization_type"] == "ground"
     assert result["status"] == "submitting"
+    assert result["upload_archive"] is True
 
     job = db.query(Job).filter_by(job_id=job_id).one()
     assert job.optimization_type == "ground"
+    assert job.archive_upload_requested is True
     assert job.job_input.input_xyz == "standard xyz input"
     assert job.job_input.keywords is None
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import uuid
 
@@ -6,6 +7,9 @@ from conftest import make_auth0_payload
 
 import storage
 from models import Job, JobInput, Tags
+from settings import get_settings
+
+VALID_XYZ = "4\nscan molecule\nC 0 0 0\nC 1 0 0\nH 1 1 0\nH 1 1 1\n"
 
 
 def _custom_data(**overrides):
@@ -31,6 +35,41 @@ def _standard_data(**overrides):
     return values
 
 
+def _scan_spec(**overrides):
+    values = {
+        "coordinate": "dihedral",
+        "atoms": [1, 2, 3, 4],
+        "relax": True,
+        "min": -180,
+        "max": 180,
+        "steps": 13,
+    }
+    values.update(overrides)
+    return values
+
+
+def _scan_data(**overrides):
+    values = {
+        "scan": json.dumps(_scan_spec()),
+        "charge": "0",
+        "multiplicity": "1",
+        "job_name": "Dihedral scan",
+    }
+    values.update(overrides)
+    return values
+
+
+def _normalized_scan_spec(**overrides):
+    values = {
+        "coordinate": "dihedral",
+        "atoms": [1, 2, 3, 4],
+        "relax": True,
+        "values": [float(value) for value in range(-180, 181, 30)],
+    }
+    values.update(overrides)
+    return values
+
+
 def _forbid_cluster_and_upload_url_calls(monkeypatch):
     def forbidden(*_args, **_kwargs):
         raise AssertionError(
@@ -42,13 +81,14 @@ def _forbid_cluster_and_upload_url_calls(monkeypatch):
 
 
 def test_openapi_documents_durable_calculation_submission_contract(client):
-    """Swagger should describe both submission forms and safe job responses."""
+    """Swagger should describe all submission forms and safe job responses."""
     schema = client.get("/openapi.json").json()
     components = schema["components"]["schemas"]
 
     for path in (
         "/calculation/custom",
         "/calculation/workflow/standard_analysis",
+        "/calculation/workflow/bond_angle_scan",
     ):
         operation = schema["paths"][path]["post"]
         response_schema = operation["responses"]["201"]["content"]["application/json"][
@@ -64,6 +104,8 @@ def test_openapi_documents_durable_calculation_submission_contract(client):
         request_schema_name = request_schema["$ref"].rsplit("/", 1)[-1]
         request_properties = components[request_schema_name]["properties"]
         assert {"file", "structure_id", "job_name"}.issubset(request_properties)
+        if path.endswith("bond_angle_scan"):
+            assert "scan" in request_properties
 
 
 @pytest.mark.parametrize(
@@ -73,6 +115,10 @@ def test_openapi_documents_durable_calculation_submission_contract(client):
         (
             "/calculation/workflow/standard_analysis",
             _standard_data(multiplicity="7"),
+        ),
+        (
+            "/calculation/workflow/bond_angle_scan",
+            _scan_data(multiplicity="7"),
         ),
     ],
 )
@@ -210,6 +256,245 @@ def test_standard_submission_uses_workflow_defaults(
     assert job.optimization_type == "ground"
     assert job.job_input.input_xyz == "standard xyz input"
     assert job.job_input.keywords is None
+
+
+def test_scan_workflow_persists_specification_and_fixed_theory(
+    client,
+    db,
+    monkeypatch,
+    user_factory,
+):
+    """A scan workflow should durably store its validated cluster inputs."""
+    _forbid_cluster_and_upload_url_calls(monkeypatch)
+    user_factory(user_sub="auth0|testuser")
+    scan_spec = _scan_spec()
+
+    response = client.post(
+        "/calculation/workflow/bond_angle_scan",
+        data=_scan_data(
+            scan=json.dumps(scan_spec),
+            charge="-1",
+            multiplicity="2",
+            job_notes=" relaxed profile ",
+            tags=["Profile"],
+        ),
+        files={"file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 201
+    result = response.json()
+    job_id = uuid.UUID(result["job_id"])
+    assert result["status"] == "submitting"
+    assert result["calculation_type"] == "scan"
+    assert result["method"] == "ccsd(t)"
+    assert result["basis_set"] == "6-311+G(2d,p)"
+    assert result["charge"] == -1
+    assert result["multiplicity"] == 2
+    assert result["optimization_type"] is None
+    assert result["job_notes"] == "relaxed profile"
+    assert result["tags"] == ["profile"]
+
+    job = db.query(Job).filter_by(job_id=job_id).one()
+    assert job.job_input.input_xyz == VALID_XYZ
+    assert job.job_input.keywords == _normalized_scan_spec()
+
+
+def test_custom_scan_uses_selected_theory_and_keyword_specification(
+    client,
+    db,
+    monkeypatch,
+    user_factory,
+):
+    """Custom scans should use the existing endpoint and selected theory."""
+    _forbid_cluster_and_upload_url_calls(monkeypatch)
+    user_factory(user_sub="auth0|testuser")
+    keywords = {"scf_type": "df", **_scan_spec()}
+
+    response = client.post(
+        "/calculation/custom",
+        data=_custom_data(
+            calculation_type="scan",
+            method="b3lyp",
+            basis_set="6-31g",
+            job_name="Custom scan",
+        ),
+        files={
+            "file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz"),
+            "keywords": (
+                "keywords.json",
+                json.dumps(keywords),
+                "application/json",
+            ),
+        },
+    )
+
+    assert response.status_code == 201
+    result = response.json()
+    assert result["calculation_type"] == "scan"
+    assert result["method"] == "b3lyp"
+    assert result["basis_set"] == "6-31g"
+    job = db.get(Job, uuid.UUID(result["job_id"]))
+    assert job.job_input.keywords == _normalized_scan_spec(scf_type="df")
+
+
+def test_custom_scan_requires_a_keyword_specification(client, db, user_factory):
+    user_factory(user_sub="auth0|testuser")
+
+    response = client.post(
+        "/calculation/custom",
+        data=_custom_data(calculation_type="scan"),
+        files={"file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Scan calculations require a scan specification in keywords"
+    )
+    assert db.query(Job).count() == 0
+
+
+@pytest.mark.parametrize(
+    "scan",
+    [
+        "not-json",
+        json.dumps(_scan_spec(coordinate=[])),
+        json.dumps(_scan_spec(coordinate="torsion")),
+        json.dumps(_scan_spec(atoms=[1, 2, 3])),
+        json.dumps(_scan_spec(atoms=[1, 2, 3, 3])),
+        json.dumps(_scan_spec(atoms=[1, 2, 3, 5])),
+        json.dumps(_scan_spec(steps=1)),
+        json.dumps(_scan_spec(values=[0, 1])),
+        json.dumps(
+            {
+                "coordinate": "bond",
+                "atoms": [1, 2],
+                "relax": False,
+                "min": 1,
+                "max": 2,
+                "spacing": 0,
+            }
+        ),
+    ],
+)
+def test_scan_workflow_rejects_invalid_specifications(
+    client,
+    db,
+    user_factory,
+    scan,
+):
+    user_factory(user_sub="auth0|testuser")
+
+    response = client.post(
+        "/calculation/workflow/bond_angle_scan",
+        data=_scan_data(scan=scan),
+        files={"file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Invalid scan specification:")
+    assert db.query(Job).count() == 0
+
+
+@pytest.mark.parametrize(
+    "range_spec",
+    [
+        {"min": 0, "max": 1, "steps": 10_000_000},
+        {"values": list(range(4))},
+        {"min": 0, "max": 3, "spacing": 1},
+    ],
+)
+def test_scan_workflow_rejects_more_than_the_configured_point_limit(
+    client,
+    db,
+    monkeypatch,
+    user_factory,
+    range_spec,
+):
+    monkeypatch.setenv("MAX_SCAN_POINTS", "3")
+    get_settings.cache_clear()
+    user_factory(user_sub="auth0|testuser")
+    scan_spec = {
+        "coordinate": "bond",
+        "atoms": [1, 2],
+        "relax": False,
+        **range_spec,
+    }
+
+    response = client.post(
+        "/calculation/workflow/bond_angle_scan",
+        data=_scan_data(scan=json.dumps(scan_spec)),
+        files={"file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 400
+    assert "must not contain more than 3 points" in response.json()["detail"]
+    assert db.query(Job).count() == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_xyz",
+    [
+        "2\ninvalid symbol\nQq 0 0 0\nH 0 0 1\n",
+        "2\ninvalid coordinate\nH nope 0 0\nH 0 0 1\n",
+        "2\nnon-finite coordinate\nH NaN 0 0\nH 0 0 1\n",
+    ],
+)
+def test_scan_workflow_rejects_invalid_xyz_atom_rows(
+    client,
+    db,
+    user_factory,
+    invalid_xyz,
+):
+    user_factory(user_sub="auth0|testuser")
+    scan_spec = {
+        "coordinate": "bond",
+        "atoms": [1, 2],
+        "relax": False,
+        "values": [0.8, 1.0],
+    }
+
+    response = client.post(
+        "/calculation/workflow/bond_angle_scan",
+        data=_scan_data(scan=json.dumps(scan_spec)),
+        files={"file": ("molecule.xyz", invalid_xyz, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 400
+    assert "invalid XYZ atom row" in response.json()["detail"]
+    assert db.query(Job).count() == 0
+
+
+def test_scan_workflow_normalizes_spacing_to_explicit_cluster_values(
+    client,
+    db,
+    monkeypatch,
+    user_factory,
+):
+    _forbid_cluster_and_upload_url_calls(monkeypatch)
+    user_factory(user_sub="auth0|testuser")
+    scan_spec = {
+        "coordinate": "bond",
+        "atoms": [1, 2],
+        "relax": False,
+        "min": 0,
+        "max": 1,
+        "spacing": 0.6,
+    }
+
+    response = client.post(
+        "/calculation/workflow/bond_angle_scan",
+        data=_scan_data(scan=json.dumps(scan_spec)),
+        files={"file": ("molecule.xyz", VALID_XYZ, "chemical/x-xyz")},
+    )
+
+    assert response.status_code == 201
+    job = db.get(Job, uuid.UUID(response.json()["job_id"]))
+    assert job.job_input.keywords == {
+        "coordinate": "bond",
+        "atoms": [1, 2],
+        "relax": False,
+        "values": [0.0, 0.6],
+    }
 
 
 def test_submission_saves_a_snapshot_of_a_readable_stored_structure(

--- a/tests/test_cluster_client.py
+++ b/tests/test_cluster_client.py
@@ -19,8 +19,9 @@ from orchestration.cluster_client import (
 from settings import BackendSettings
 
 JOB_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
-WORK_DIR = PurePosixPath("/home/test/molmaker")
-REMOTE_COMMAND = "python3 /home/test/molmaker/Cluster-API-QC/runner/dispatch.py"
+SSH_HOST = "cluster-test"
+DISPATCH_PATH = PurePosixPath("/home/test/cluster/runner/dispatch.py")
+REMOTE_COMMAND = f"python3 {DISPATCH_PATH}"
 
 
 def success(result):
@@ -58,7 +59,8 @@ def finalisation_success(**overrides):
 @pytest.fixture
 def client():
     return ClusterDispatchClient(
-        WORK_DIR,
+        SSH_HOST,
+        DISPATCH_PATH,
         timeout_seconds=37,
         storage_timeout_seconds=41,
     )
@@ -107,7 +109,7 @@ def submit(client, **overrides):
 def sent_request(calls, *, timeout=37):
     assert len(calls) == 1
     command, options = calls[0]
-    assert command == ["ssh", "cluster", REMOTE_COMMAND]
+    assert command == ["ssh", SSH_HOST, REMOTE_COMMAND]
     assert options["check"] is False
     assert options["capture_output"] is True
     assert options["text"] is True
@@ -118,13 +120,22 @@ def sent_request(calls, *, timeout=37):
 
 
 def test_client_reads_cluster_settings(monkeypatch):
-    monkeypatch.setenv("CLUSTER_WORK_DIR", "/remote/molmaker")
+    monkeypatch.setenv("CLUSTER_SSH_HOST", "remote-cluster")
+    monkeypatch.setenv(
+        "CLUSTER_DISPATCH_PATH",
+        "/remote/molmaker/cluster-runtime/dispatch.py",
+    )
     monkeypatch.setenv("SLURM_COMMAND_TIMEOUT_SECONDS", "45")
     monkeypatch.setenv("STORAGE_OPERATION_TIMEOUT_SECONDS", "46")
 
-    client = ClusterDispatchClient.from_settings(BackendSettings.from_env())
+    client = ClusterDispatchClient.from_settings(
+        BackendSettings.from_env().orchestration
+    )
 
-    assert client.cluster_work_dir == PurePosixPath("/remote/molmaker")
+    assert client.ssh_host == "remote-cluster"
+    assert client.dispatch_path == PurePosixPath(
+        "/remote/molmaker/cluster-runtime/dispatch.py"
+    )
     assert client.timeout_seconds == 45
     assert client.storage_timeout_seconds == 46
 
@@ -238,6 +249,7 @@ def test_finalisation_sends_one_archive_url_and_returns_database_content(
     )
 
     assert result == FinalisationResult(
+        archive_uploaded=True,
         calculation_result={"energy": -75.2},
         calculation_error=None,
         artifacts={"vib": "vibration data"},
@@ -252,6 +264,60 @@ def test_finalisation_sends_one_archive_url_and_returns_database_content(
         "archive_upload_url": secret_url,
         "allow_missing_error": False,
     }
+
+
+def test_finalisation_without_an_archive_returns_results_and_sends_null(
+    client,
+    run_dispatch,
+):
+    calls = run_dispatch(stdout=finalisation_success(archive_uploaded=False))
+
+    result = client.upload_artifacts(
+        job_id=JOB_ID,
+        calculation_type=CalculationType.energy,
+        terminal_status=JobStatus.completed,
+        archive_upload_url=None,
+    )
+
+    assert result.archive_uploaded is False
+    assert result.calculation_result == {"energy": -75.2}
+    assert sent_request(calls, timeout=41)["archive_upload_url"] is None
+
+
+def test_finalisation_accepts_an_unavailable_requested_archive(
+    client,
+    run_dispatch,
+):
+    calls = run_dispatch(stdout=finalisation_success(archive_uploaded=False))
+    archive_url = "https://storage.example/archive"
+
+    result = client.upload_artifacts(
+        job_id=JOB_ID,
+        calculation_type=CalculationType.energy,
+        terminal_status=JobStatus.completed,
+        archive_upload_url=archive_url,
+    )
+
+    assert result.archive_uploaded is False
+    assert sent_request(calls, timeout=41)["archive_upload_url"] == archive_url
+
+
+def test_finalisation_rejects_an_upload_reported_without_a_destination(
+    client,
+    run_dispatch,
+):
+    run_dispatch(stdout=finalisation_success(archive_uploaded=True))
+
+    with pytest.raises(
+        ClusterServiceError,
+        match="Invalid artifact finalisation response",
+    ):
+        client.upload_artifacts(
+            job_id=JOB_ID,
+            calculation_type=CalculationType.energy,
+            terminal_status=JobStatus.completed,
+            archive_upload_url=None,
+        )
 
 
 def test_finalisation_acknowledges_only_the_matching_job(
@@ -273,7 +339,7 @@ def test_finalisation_acknowledges_only_the_matching_job(
     "response",
     [
         finalisation_success(job_id="22222222-2222-4222-8222-222222222222"),
-        finalisation_success(archive_uploaded=False),
+        finalisation_success(archive_uploaded="yes"),
         finalisation_success(calculation_result=[]),
         finalisation_success(calculation_error=[]),
         finalisation_success(artifacts=[]),

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,6 +29,10 @@ def test_init_db_creates_the_current_schema(db, monkeypatch):
     assert structure_columns["content"]["nullable"] is False
     assert structure_columns["thumbnail"]["nullable"] is False
     assert structure_columns["thumbnail_media_type"]["nullable"] is False
+    job_columns = {column["name"]: column for column in inspector.get_columns("jobs")}
+    assert job_columns["archive_upload_requested"]["nullable"] is False
+    assert job_columns["archive_uploaded"]["nullable"] is False
+    assert job_columns["archive_upload_status"]["nullable"] is False
 
 
 def test_database_module_entrypoint_creates_the_current_schema():

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,4 +1,5 @@
 from enum_types import (
+    ArchiveUploadStatus,
     CalculationType,
     JobFailureReason,
     JobStatus,
@@ -9,6 +10,15 @@ from enum_types import (
     optimization_types,
     wave_functional_theories,
 )
+
+
+def test_archive_upload_status_values_match_the_database_contract():
+    assert {status.value for status in ArchiveUploadStatus} == {
+        "pending",
+        "disabled",
+        "uploaded",
+        "unavailable",
+    }
 
 
 def test_job_status_values_match_the_orchestration_contract():

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,4 +1,5 @@
 from enum_types import (
+    CalculationType,
     JobFailureReason,
     JobStatus,
     basis_sets,
@@ -20,6 +21,11 @@ def test_job_status_values_match_the_orchestration_contract():
         "failed",
         "cancelled",
     }
+
+
+def test_calculation_types_include_scan():
+    assert CalculationType.scan.value == "scan"
+    assert calculation_types["Bond/Angle Scan"] == "scan"
 
 
 def test_job_failure_reason_values_are_separate_from_statuses():

--- a/tests/test_finalisation_reconciler.py
+++ b/tests/test_finalisation_reconciler.py
@@ -7,7 +7,12 @@ import pytest
 from conftest import TestingSessionLocal
 
 from asset_service import serialize_job, upsert_job_result
-from enum_types import CalculationType, JobFailureReason, JobStatus
+from enum_types import (
+    ArchiveUploadStatus,
+    CalculationType,
+    JobFailureReason,
+    JobStatus,
+)
 from models import Job
 from orchestration.cluster_client import (
     ClusterDispatchClient,
@@ -48,6 +53,7 @@ def make_reconciler(settings, user_factory):
         client=None,
         current_settings=None,
         generate_upload_url=None,
+        archive_upload_enabled=True,
         sleep=None,
         clock=None,
     ):
@@ -58,6 +64,7 @@ def make_reconciler(settings, user_factory):
             session_factory=TestingSessionLocal,
             cluster_client=client,
             settings=current_settings or settings,
+            archive_upload_enabled=archive_upload_enabled,
             generate_upload_url=generate_upload_url
             or Mock(return_value="https://upload.test/archive"),
             sleep=sleep or Mock(),
@@ -84,6 +91,7 @@ def finalising_job(job_factory, **overrides):
 
 def completed_result(**overrides):
     values = {
+        "archive_uploaded": True,
         "calculation_result": {"energy": -75.2},
         "calculation_error": None,
         "artifacts": {},
@@ -194,6 +202,8 @@ def test_success_publishes_each_terminal_status(
     assert saved.status == terminal_status.value
     assert saved.terminal_status == terminal_status.value
     assert saved.is_uploaded is True
+    assert saved.archive_uploaded is True
+    assert saved.archive_upload_status == ArchiveUploadStatus.uploaded.value
     assert saved.completed_at is not None
     assert saved.attempt_count == 0
     assert saved.failure_reason == failure_reason
@@ -205,6 +215,120 @@ def test_success_publishes_each_terminal_status(
         archive_upload_url="https://upload.test/archive",
         allow_missing_error=allow_missing_error,
     )
+    client.acknowledge_finalisation.assert_called_once_with(job.job_id)
+
+
+@pytest.mark.parametrize(
+    ("terminal_status", "failure_reason", "calculation_result", "calculation_error"),
+    [
+        (JobStatus.completed, None, {"energy": -75.2}, None),
+        (
+            JobStatus.failed,
+            JobFailureReason.calculation_failed.value,
+            None,
+            {"message": "calculation failed"},
+        ),
+        (JobStatus.cancelled, None, None, None),
+    ],
+)
+def test_archive_disabled_publishes_results_without_s3(
+    db,
+    job_factory,
+    make_reconciler,
+    terminal_status,
+    failure_reason,
+    calculation_result,
+    calculation_error,
+):
+    client = Mock(spec=ClusterDispatchClient)
+    client.upload_artifacts.return_value = completed_result(
+        archive_uploaded=False,
+        calculation_result=calculation_result,
+        calculation_error=calculation_error,
+    )
+    generate = Mock(side_effect=AssertionError("S3 must not be used"))
+    reconciler = make_reconciler(
+        client=client,
+        generate_upload_url=generate,
+        archive_upload_enabled=False,
+    )
+    job = finalising_job(
+        job_factory,
+        terminal_status=terminal_status.value,
+        failure_reason=failure_reason,
+    )
+
+    reconciler.run_round()
+
+    saved = refresh(db, job)
+    assert saved.status == terminal_status.value
+    assert saved.terminal_status == terminal_status.value
+    assert saved.is_uploaded is True
+    assert saved.archive_uploaded is False
+    assert saved.archive_upload_status == ArchiveUploadStatus.disabled.value
+    assert saved.job_result is not None
+    generate.assert_not_called()
+    client.upload_artifacts.assert_called_once_with(
+        job_id=job.job_id,
+        calculation_type=CalculationType.energy,
+        terminal_status=terminal_status,
+        archive_upload_url=None,
+        allow_missing_error=(terminal_status == JobStatus.cancelled),
+    )
+    client.acknowledge_finalisation.assert_called_once_with(job.job_id)
+
+
+def test_job_archive_opt_out_skips_s3_when_uploads_are_globally_enabled(
+    db,
+    job_factory,
+    make_reconciler,
+):
+    client = Mock(spec=ClusterDispatchClient)
+    client.upload_artifacts.return_value = completed_result(archive_uploaded=False)
+    generate = Mock(side_effect=AssertionError("S3 must not be used"))
+    reconciler = make_reconciler(
+        client=client,
+        generate_upload_url=generate,
+        archive_upload_enabled=True,
+    )
+    job = finalising_job(job_factory, archive_upload_requested=False)
+
+    reconciler.run_round()
+
+    saved = refresh(db, job)
+    assert saved.status == JobStatus.completed.value
+    assert saved.archive_upload_requested is False
+    assert saved.archive_uploaded is False
+    assert saved.archive_upload_status == ArchiveUploadStatus.disabled.value
+    generate.assert_not_called()
+    client.upload_artifacts.assert_called_once_with(
+        job_id=job.job_id,
+        calculation_type=CalculationType.energy,
+        terminal_status=JobStatus.completed,
+        archive_upload_url=None,
+        allow_missing_error=False,
+    )
+    client.acknowledge_finalisation.assert_called_once_with(job.job_id)
+
+
+def test_returned_archive_unavailability_does_not_fail_the_job(
+    db,
+    job_factory,
+    make_reconciler,
+):
+    client = Mock(spec=ClusterDispatchClient)
+    client.upload_artifacts.return_value = completed_result(archive_uploaded=False)
+    reconciler = make_reconciler(client=client)
+    job = finalising_job(job_factory)
+
+    reconciler.run_round()
+
+    saved = refresh(db, job)
+    assert saved.status == JobStatus.completed.value
+    assert saved.is_uploaded is True
+    assert saved.archive_uploaded is False
+    assert saved.archive_upload_status == ArchiveUploadStatus.unavailable.value
+    assert saved.failure_reason is None
     client.acknowledge_finalisation.assert_called_once_with(job.job_id)
 
 
@@ -291,6 +415,8 @@ def test_saved_result_retries_acknowledgement_without_reuploading(
         error=None,
         artifacts={},
     )
+    job.archive_uploaded = True
+    job.archive_upload_status = ArchiveUploadStatus.uploaded.value
     db.commit()
 
     reconciler.run_round()

--- a/tests/test_job_result_persistence.py
+++ b/tests/test_job_result_persistence.py
@@ -18,6 +18,7 @@ COMPLETED_RESULTS = [
     ("optimization", {"trajectory": "trajectory data"}),
     ("transition", {"trajectory": "trajectory data"}),
     ("irc", {"trajectory": "trajectory data"}),
+    ("scan", {"scan": "scan trajectory data"}),
     (
         "standard",
         {

--- a/tests/test_job_result_persistence.py
+++ b/tests/test_job_result_persistence.py
@@ -8,7 +8,7 @@ from asset_service import (
     publish_job_result,
     upsert_job_result,
 )
-from enum_types import JobFailureReason, JobStatus
+from enum_types import ArchiveUploadStatus, JobFailureReason, JobStatus
 from models import Job, JobResult
 
 COMPLETED_RESULTS = [
@@ -66,6 +66,8 @@ def test_publishes_completed_result_and_job_together(
     assert saved_result.artifacts == artifacts
     assert saved_job.status == JobStatus.completed.value
     assert saved_job.is_uploaded is True
+    assert saved_job.archive_uploaded is False
+    assert saved_job.archive_upload_status == ArchiveUploadStatus.unavailable.value
     assert saved_job.completed_at is not None
     assert saved_job.attempt_count == 0
 
@@ -89,6 +91,48 @@ def test_stages_an_upsert_without_publishing_the_job(db, job_factory):
     assert db.get(JobResult, job.job_id) is job_result
     assert job.status == JobStatus.finalising.value
     assert job.is_uploaded is False
+    assert job.archive_upload_status == ArchiveUploadStatus.pending.value
+
+
+def test_publishes_uploaded_archive_outcome_with_the_result(db, job_factory):
+    job = job_factory(
+        status=JobStatus.finalising.value,
+        terminal_status=JobStatus.completed.value,
+    )
+
+    publish_job_result(
+        db,
+        job,
+        result={"success": True},
+        error=None,
+        artifacts={},
+        archive_uploaded=True,
+        archive_upload_status=ArchiveUploadStatus.uploaded,
+    )
+
+    assert job.archive_uploaded is True
+    assert job.archive_upload_status == ArchiveUploadStatus.uploaded.value
+
+
+def test_rejects_an_inconsistent_archive_outcome(db, job_factory):
+    job = job_factory(
+        status=JobStatus.finalising.value,
+        terminal_status=JobStatus.completed.value,
+    )
+
+    with pytest.raises(
+        JobResultValidationError,
+        match="Archive upload outcome is inconsistent",
+    ):
+        publish_job_result(
+            db,
+            job,
+            result={"success": True},
+            error=None,
+            artifacts={},
+            archive_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.disabled,
+        )
 
 
 def test_retry_updates_the_same_result_row_and_keeps_completion_time(

--- a/tests/test_job_results.py
+++ b/tests/test_job_results.py
@@ -100,6 +100,12 @@ class TestJobResultEndpoints:
                 "trajectory.xyz",
             ),
             ("vib", "vibration text", "chemical/x-xyz", "vib.xyz"),
+            (
+                "scan",
+                "2\nscan point\nH 0 0 0\nH 0 0 1\n",
+                "chemical/x-xyz",
+                "scan.xyz",
+            ),
             ("molden", "[Molden Format]", "text/plain", "orbitals.molden"),
             ("esp", "cube text", "text/plain", "ESP.cube"),
         ],

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -40,6 +40,9 @@ def test_openapi_documents_job_response_and_metadata_patch(client):
         "cancel_requested",
         "failure_reason",
         "failure_message",
+        "upload_archive",
+        "archive_uploaded",
+        "archive_upload_status",
         "structures",
     }.issubset(response_properties)
     assert {

--- a/tests/test_orchestration_lifecycle.py
+++ b/tests/test_orchestration_lifecycle.py
@@ -111,6 +111,7 @@ def test_api_job_moves_through_all_three_reconcilers(
     assert finalising.terminal_status == JobStatus.completed.value
 
     cluster_client.upload_artifacts.return_value = FinalisationResult(
+        archive_uploaded=True,
         calculation_result={"energy": -75.2},
         calculation_error=None,
         artifacts={},
@@ -120,6 +121,7 @@ def test_api_job_moves_through_all_three_reconcilers(
         session_factory=TestingSessionLocal,
         cluster_client=cluster_client,
         settings=settings,
+        archive_upload_enabled=True,
         generate_upload_url=Mock(return_value="https://upload.test/archive"),
         sleep=Mock(),
         clock=Mock(return_value=0.0),

--- a/tests/test_orchestration_settings.py
+++ b/tests/test_orchestration_settings.py
@@ -9,12 +9,17 @@ from settings import (
 )
 
 SETTING_NAMES = tuple(ORCHESTRATION_DEFAULTS)
+ORCHESTRATION_ENVIRONMENT_NAMES = (
+    "CLUSTER_SSH_HOST",
+    "CLUSTER_DISPATCH_PATH",
+    *SETTING_NAMES,
+)
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(autouse=True)
 def clear_orchestration_environment(monkeypatch):
-    for name in SETTING_NAMES:
+    for name in ORCHESTRATION_ENVIRONMENT_NAMES:
         monkeypatch.delenv(name, raising=False)
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,7 @@ from sqlalchemy.engine import make_url
 import orchestration.finalisation_reconciler as finalisation_module
 import orchestration.status_reconciler as status_module
 import orchestration.submission_reconciler as submission_module
+import settings as settings_module
 import storage
 from main import create_app
 from orchestration.cluster_client import ClusterDispatchClient
@@ -16,6 +17,7 @@ from orchestration.submission_reconciler import SubmissionReconciler
 from settings import (
     APPLICATION_DEFAULTS,
     CALCULATION_DEFAULTS,
+    ENV_FILE_VARIABLE,
     SUPPORTED_ENVIRONMENT_VARIABLES,
     BackendSettings,
     get_settings,
@@ -59,6 +61,92 @@ def test_scan_point_limit_is_configurable(monkeypatch):
     monkeypatch.setenv("MAX_SCAN_POINTS", "321")
 
     assert BackendSettings.from_env().max_scan_points == 321
+
+
+def test_archive_upload_switch_is_strict_and_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("ARCHIVE_UPLOAD_ENABLED", raising=False)
+    assert BackendSettings.from_env().archive_upload_enabled is True
+
+    monkeypatch.setenv("ARCHIVE_UPLOAD_ENABLED", "false")
+    assert BackendSettings.from_env().archive_upload_enabled is False
+
+    monkeypatch.setenv("ARCHIVE_UPLOAD_ENABLED", "yes")
+    with pytest.raises(ValueError, match="ARCHIVE_UPLOAD_ENABLED"):
+        BackendSettings.from_env()
+
+
+def test_explicit_env_file_loads_without_overriding_process_values(
+    monkeypatch,
+    tmp_path,
+):
+    env_file = tmp_path / "backend.env"
+    env_file.write_text(
+        "CLUSTER_SSH_HOST=file-host\n"
+        "CLUSTER_DISPATCH_PATH=/cluster/from-file/dispatch.py\n"
+        "ARCHIVE_UPLOAD_ENABLED=false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(ENV_FILE_VARIABLE, str(env_file))
+    monkeypatch.setenv("CLUSTER_SSH_HOST", "process-host")
+    monkeypatch.delenv("CLUSTER_DISPATCH_PATH", raising=False)
+    monkeypatch.delenv("ARCHIVE_UPLOAD_ENABLED", raising=False)
+
+    settings = get_settings()
+
+    assert settings.orchestration.cluster_ssh_host == "process-host"
+    assert settings.orchestration.cluster_dispatch_path == Path(
+        "/cluster/from-file/dispatch.py"
+    )
+    assert settings.archive_upload_enabled is False
+
+
+def test_repository_env_file_is_the_fallback(monkeypatch, tmp_path):
+    env_file = tmp_path / "fallback.env"
+    env_file.write_text("ARCHIVE_UPLOAD_ENABLED=false\n", encoding="utf-8")
+    monkeypatch.delenv(ENV_FILE_VARIABLE, raising=False)
+    monkeypatch.delenv("ARCHIVE_UPLOAD_ENABLED", raising=False)
+    monkeypatch.setattr(settings_module, "DEFAULT_ENV_FILE", env_file)
+
+    assert get_settings().archive_upload_enabled is False
+
+
+@pytest.mark.parametrize("configured_path", ["relative.env", "missing.env"])
+def test_explicit_env_file_must_be_absolute_and_exist(
+    monkeypatch,
+    tmp_path,
+    configured_path,
+):
+    path = configured_path
+    if configured_path == "missing.env":
+        path = str(tmp_path / configured_path)
+    monkeypatch.setenv(ENV_FILE_VARIABLE, path)
+
+    with pytest.raises(ValueError, match=ENV_FILE_VARIABLE):
+        get_settings()
+
+
+def test_cluster_dispatch_requires_independent_host_and_absolute_path(monkeypatch):
+    monkeypatch.delenv("CLUSTER_SSH_HOST", raising=False)
+    monkeypatch.delenv("CLUSTER_DISPATCH_PATH", raising=False)
+
+    with pytest.raises(EnvironmentError) as error:
+        BackendSettings.from_env().orchestration.require_cluster_dispatch()
+
+    assert "CLUSTER_SSH_HOST" in str(error.value)
+    assert "CLUSTER_DISPATCH_PATH" in str(error.value)
+
+    monkeypatch.setenv("CLUSTER_SSH_HOST", "cluster-test")
+    monkeypatch.setenv("CLUSTER_DISPATCH_PATH", "relative/dispatch.py")
+    with pytest.raises(ValueError, match="CLUSTER_DISPATCH_PATH"):
+        BackendSettings.from_env()
+
+
+@pytest.mark.parametrize("host", ["-unsafe", "two hosts", "host\ncommand"])
+def test_cluster_ssh_host_rejects_option_and_whitespace_values(monkeypatch, host):
+    monkeypatch.setenv("CLUSTER_SSH_HOST", host)
+
+    with pytest.raises(ValueError, match="CLUSTER_SSH_HOST"):
+        BackendSettings.from_env()
 
 
 @pytest.mark.parametrize("invalid_limit", ["invalid", "0", "1", "10001"])
@@ -162,7 +250,12 @@ def test_api_and_reconcilers_use_the_same_settings(
     monkeypatch,
     mocker,
 ):
-    monkeypatch.setenv("CLUSTER_WORK_DIR", "/cluster/molmaker")
+    monkeypatch.setenv("CLUSTER_SSH_HOST", "cluster-test")
+    monkeypatch.setenv(
+        "CLUSTER_DISPATCH_PATH",
+        "/cluster/molmaker/Cluster-API-QC/runner/dispatch.py",
+    )
+    monkeypatch.setenv("ARCHIVE_UPLOAD_ENABLED", "true")
     get_settings.cache_clear()
     settings = get_settings()
     session_factory = Mock()
@@ -193,10 +286,11 @@ def test_api_and_reconcilers_use_the_same_settings(
     assert all(
         reconciler.settings is settings.orchestration for reconciler in reconcilers
     )
+    assert reconcilers[-1].archive_upload_enabled is True
     assert cluster_factory.call_args_list == [
-        call(settings),
-        call(settings),
-        call(settings),
+        call(settings.orchestration),
+        call(settings.orchestration),
+        call(settings.orchestration),
     ]
 
 
@@ -218,3 +312,12 @@ def test_application_modules_do_not_read_environment_directly():
                 )
 
     assert violations == []
+
+
+def test_reconciler_service_selects_the_backend_env_file_explicitly():
+    service = (
+        PROJECT_ROOT / "deploy" / "systemd" / "molmaker-reconciler@.service"
+    ).read_text(encoding="utf-8")
+
+    assert "Environment=BACKEND_ENV_FILE=/etc/molmaker/backend.env" in service
+    assert "EnvironmentFile=" not in service

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,6 +15,7 @@ from orchestration.status_reconciler import StatusReconciler
 from orchestration.submission_reconciler import SubmissionReconciler
 from settings import (
     APPLICATION_DEFAULTS,
+    CALCULATION_DEFAULTS,
     SUPPORTED_ENVIRONMENT_VARIABLES,
     BackendSettings,
     get_settings,
@@ -50,6 +51,22 @@ def test_env_example_lists_every_supported_backend_setting():
     assert set(example_values) == SUPPORTED_ENVIRONMENT_VARIABLES
     for name, default in APPLICATION_DEFAULTS.items():
         assert example_values[name] == default
+    for name, default in CALCULATION_DEFAULTS.items():
+        assert example_values[name] == str(default)
+
+
+def test_scan_point_limit_is_configurable(monkeypatch):
+    monkeypatch.setenv("MAX_SCAN_POINTS", "321")
+
+    assert BackendSettings.from_env().max_scan_points == 321
+
+
+@pytest.mark.parametrize("invalid_limit", ["invalid", "0", "1", "10001"])
+def test_scan_point_limit_is_bounded(monkeypatch, invalid_limit):
+    monkeypatch.setenv("MAX_SCAN_POINTS", invalid_limit)
+
+    with pytest.raises(ValueError, match="MAX_SCAN_POINTS"):
+        BackendSettings.from_env()
 
 
 def test_database_settings_build_a_safe_url(monkeypatch):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,7 @@ from botocore.exceptions import EndpointConnectionError
 from conftest import make_auth0_payload
 
 import storage
-from enum_types import JobStatus
+from enum_types import ArchiveUploadStatus, JobStatus
 from settings import get_settings
 
 
@@ -130,6 +130,8 @@ class TestJobArchiveEndpoint:
             is_public=access == "public_group_member",
             status=JobStatus.completed.value,
             is_uploaded=True,
+            archive_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.uploaded.value,
         )
         job_result_factory(job=job)
         set_auth_user(make_auth0_payload(actor.user_sub))
@@ -221,7 +223,30 @@ class TestJobArchiveEndpoint:
         response = client.get(f"/storage/jobs/{job.job_id}/archive")
 
         assert response.status_code == 409
-        assert response.json()["detail"] == "Job files are not ready"
+        assert response.json()["detail"] == "Job archive is not ready"
+        assert mock_archive_url == []
+
+    def test_saved_results_do_not_imply_that_an_archive_exists(
+        self,
+        client,
+        user_factory,
+        job_factory,
+        job_result_factory,
+        mock_archive_url,
+    ):
+        user_factory(user_sub="auth0|testuser")
+        job = job_factory(
+            status=JobStatus.completed.value,
+            is_uploaded=True,
+            archive_uploaded=False,
+            archive_upload_status=ArchiveUploadStatus.disabled.value,
+        )
+        job_result_factory(job=job)
+
+        response = client.get(f"/storage/jobs/{job.job_id}/archive")
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "Job archive is unavailable"
         assert mock_archive_url == []
 
     @pytest.mark.parametrize(
@@ -242,7 +267,12 @@ class TestJobArchiveEndpoint:
         job_status,
     ):
         user_factory(user_sub="auth0|testuser")
-        job = job_factory(status=job_status, is_uploaded=True)
+        job = job_factory(
+            status=job_status,
+            is_uploaded=True,
+            archive_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.uploaded.value,
+        )
         job_result_factory(job=job)
 
         response = client.get(f"/storage/jobs/{job.job_id}/archive")
@@ -267,6 +297,8 @@ class TestJobArchiveEndpoint:
             terminal_status=JobStatus.completed.value,
             completed_at=datetime.now(timezone.utc),
             is_uploaded=True,
+            archive_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.uploaded.value,
         )
         job_result_factory(job=job)
 
@@ -286,6 +318,8 @@ class TestJobArchiveEndpoint:
         job = job_factory(
             status=JobStatus.completed.value,
             is_uploaded=True,
+            archive_uploaded=True,
+            archive_upload_status=ArchiveUploadStatus.uploaded.value,
         )
         job_result_factory(job=job)
 

--- a/tests/test_submission_reconciler.py
+++ b/tests/test_submission_reconciler.py
@@ -190,6 +190,37 @@ def test_success_commits_attempt_then_submits_the_database_inputs(
     client.submit_job.assert_called_once()
 
 
+def test_scan_submission_passes_the_stored_scan_specification(
+    db,
+    job_factory,
+    make_reconciler,
+):
+    client = Mock(spec=ClusterDispatchClient)
+    client.submit_job.return_value = "45678"
+    reconciler = make_reconciler(client=client)
+    scan_spec = {
+        "coordinate": "bond",
+        "atoms": [1, 2],
+        "relax": False,
+        "values": [0.9, 1.0, 1.1],
+    }
+    job = job_factory(
+        calculation_type=CalculationType.scan.value,
+        method="ccsd(t)",
+        basis_set="6-311+G(2d,p)",
+        input_xyz="2\nscan molecule\nH 0 0 0\nH 0 0 1\n",
+        keywords=scan_spec,
+    )
+
+    reconciler.run_round()
+
+    assert refresh(db, job).status == JobStatus.submitted.value
+    assert client.submit_job.call_args.kwargs["calculation_type"] == (
+        CalculationType.scan
+    )
+    assert client.submit_job.call_args.kwargs["keywords"] == scan_spec
+
+
 def test_retry_uses_one_recovering_submission_request(
     db,
     job_factory,


### PR DESCRIPTION
## Summary

- add POST /calculation/workflow/bond_angle_scan for the dedicated Scan workflow
- allow custom calculations to use calculation_type=scan with caller-selected theory
- validate and normalize bond, angle, and dihedral specifications against XYZ atom rows
- persist explicit scan values and pass them through the asynchronous cluster-dispatch flow
- expose scan results and scan.xyz through the existing job result and artifact endpoints

## Configuration and archives

- centralize backend configuration in the shared settings layer
- add MAX_SCAN_POINTS, defaulting to 200
- add ARCHIVE_UPLOAD_ENABLED as the deployment-wide archive upload switch
- preserve per-job archive requests while allowing archive-free result finalization
- document the new settings in .env.example and deployment documentation

## Verification

- Ruff lint and formatting checks
- 678 PostgreSQL tests passed, 1 skipped

## Related work

- UBCC3/react-ui#38
- UBCC3/Cluster-API-QC#8